### PR TITLE
Add:投稿機能に関するpostsテーブル、embedsテーブル、prefectureモデルの作成を行い、postsにおいてnew,create,showの機能を実装しました

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,40 @@
+class PostsController < ApplicationController
+  skip_before_action :require_login, only: %i[index new show]
+  before_action :set_post, only: %i[show destroy]
+
+  def index
+    @posts = Post.all.includes(:user).order(created_at: :desc)
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      redirect_to posts_path, success: t('defaults.messages.post_create_success')
+    else
+      flash.now[:danger] = t('defaults.messages.post_create_failed')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update; end
+
+  def destroy; end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:memory, :music_name)
+  end
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,6 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :login_limited, only: %i[new create]
 
   def new
     @user = User.new
@@ -8,7 +9,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to users_path, success: t('defaults.messages.login_success')
+      redirect_back_or_to root_path, success: t('defaults.messages.login_success')
     else
       flash.now[:danger] = t('defaults.messages.login_failed')
       render :new, status: :unprocessable_entity
@@ -18,5 +19,11 @@ class UserSessionsController < ApplicationController
   def destroy
     logout
     redirect_to login_path, success: t('defaults.messages.logout_success')
+  end
+
+  private
+
+  def login_limited
+    redirect_to root_path, warning: t('defaults.messages.login_limited') if logged_in?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :login_limited, only: %i[new create]
 
   def index
     @users = User.all
@@ -27,5 +28,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def login_limited
+    redirect_to root_path, warning: t('defaults.messages.login_limited') if logged_in?
   end
 end

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -1,0 +1,5 @@
+class Embed < ApplicationRecord
+  has_many :posts, dependent: :destroy
+  
+  enum embed_type: { youtube: 0, apple_music: 1, spotify: 2}
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,30 @@
+class Post < ApplicationRecord
+  belongs_to :user
+  #belongs_to :embed
+  
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :prefecture
+
+  with_options presence: true do
+    validates :music_name
+    validates :memory
+  end
+
+  enum age_group: { childhood: 0,
+                    elementary: 5, 
+                    middle: 10, 
+                    high: 15, 
+                    early_20s: 20, 
+                    late_20s: 25,
+                    early_30s: 30,
+                    late_30s: 35,
+                    early_40s: 40,
+                    late_40s: 45,
+                    early_50s: 50,
+                    late_50s: 55,
+                    early_60s: 60,
+                    late_60s: 65,
+                    early_70s: 70,
+                    late_70s: 75,
+                  }
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,24 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+    {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+    {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+    {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+    {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+    {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+    {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+    {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+    {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+    {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+    {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+    {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+    {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+    {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+    {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+    {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+
+  include ActiveHash::Associations
+  has_many :posts
+  has_many :users
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :posts, dependent: :destroy
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :prefecture
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
@@ -7,4 +11,8 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
+
+  def mine?(object)
+    object.user_id == self.id
+  end
 end

--- a/app/views/posts/_crud_menu.html.erb
+++ b/app/views/posts/_crud_menu.html.erb
@@ -1,0 +1,23 @@
+<ul class="list-unstyled list-inline float-right">
+  <li class="list-inline-item">
+    <% unless current_page?(post_path(post)) %>
+      <%= link_to post_path(post) do %>
+        <i class="fas fa-search"></i> 
+      <% end %>
+    <% end %>
+  </li>
+  <% if logged_in? && current_user.mine?(post) %>
+    <li class="list-inline-item">
+      <%= link_to '#' do %>
+        <i class="fa-solid fa-pen"></i>
+      <% end %>
+    </li>
+    <li class="list-inline-item">
+      <%= link_to '#' do %>
+        <i class="fa-solid fa-trash-can"></i>
+      <% end %>
+    </li>
+    <li class="list-inline-item">
+    </li>
+  <% end %>
+</ul>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: post, class: "offset-md-1 offset-lg-2 col-md-10 col-lg-8", local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="mb-3">
+    <%= f.label :music_name %><br />
+    <%= f.text_field :music_name, class: "form-control", placeholder: "曲名", value: post.music_name %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :memory %><br />
+    <%= f.text_area :memory, class: "form-control", placeholder: "あなたのこの曲の思い出を書きましょう", value: post.memory %>
+  </div>
+  <div class="mb-3 text-center mt-4">
+    <%= f.submit "投稿", class:"btn btn-primary w-50" %>
+  </div>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,14 @@
+<div class="card p-3">
+  <table>
+    <div><%= link_to post.music_name, post_path(post), class: "fs-2" %></div>
+    <tr>
+      <td><%= Post.human_attribute_name(:memory) %></td>
+      <td><%= post.memory %></td>
+    </tr>
+    <tr>
+      <td><%= t('defaults.contributor') %></td>
+      <td><%= post.user.name %></td>
+    </tr>
+  </table>
+  <%= render 'crud_menu', post: post %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,13 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="row">
+    <div class="col-10 offset-1">
+      <h1 class="mt-4 mb-4"><%= t('.title') %></h1>
+      <% if @posts.present? %>
+        <%= render @posts %>
+      <% else %>
+        <div>投稿はありません</div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:title, t('.title')) %>
+<div class="form-signin m-auto col-6 offset-3">
+  <h1 class="text-center mb-4"><%= t('.title') %></h1>  
+  <%= render 'form', post: @post %>
+  <div class="text-center">
+    <%= link_to '戻る', posts_path %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for(:title, "#{Post.human_attribute_name(:music_name)}:#{@post.music_name}") %>
+<div class="col-8 offset-2">
+  <h1 class="mt-4 mb-4"><%= t('.title') %></h1>
+  <table class="table table-light">
+    <tr>
+      <th><%= t('defaults.contributor') %></th>
+      <td><%= @post.user.name %></td>
+    </tr>
+    <tr>
+      <th><%= Post.human_attribute_name(:music_name) %></th>
+      <td><%= @post.music_name %></td>
+    </tr>
+    <tr>
+      <th><%= Post.human_attribute_name(:memory) %></th>
+      <td><%= @post.memory %></td>
+    </tr>
+  </table>
+  <%= render 'crud_menu', post: @post %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="p-3 mb-3 border-bottom">
   <div class="container">
     <div class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-      <%= link_to '#', data: {"turbolinks" => false}, class:"d-flex align-items-center mb-3 mb-md-0 me-md-auto link-body-emphasis text-decoration-none" do %>
+      <%= link_to posts_path, data: {"turbolinks" => false}, class:"d-flex align-items-center mb-3 mb-md-0 me-md-auto link-body-emphasis text-decoration-none" do %>
         <svg class="bi me-2" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
         <h1 class="fs-2">Music Memory</h1>
       <% end %>
@@ -15,7 +15,7 @@
             <% end %>
           </li>
           <li class="nav-item"><%= link_to "Mypage", '#', class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to "新規投稿", '#', class: "nav-link" %></li>
+          <li class="nav-item"><%= link_to "新規投稿", new_post_path, class: "nav-link" %></li>
           <li class="nav-item"><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "nav-link" %></li>
         <% else %>
           <li class="nav-item"><%= link_to "Home", '#', class: "nav-link" %></li>
@@ -24,6 +24,11 @@
           <li class="nav-item"><%= link_to t('defaults.signup'), signup_path, class: "nav-link" %></li>
         <% end %>
       </ul>
+      <div class="text-right">
+        <% if logged_in? %>
+          <small>[ID:<%= current_user.id %>]<%= current_user.name %></small>
+        <% end %>
+      </div>
     </div>
   </div>
 </header>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
 <div class="form-signin m-auto col-6 offset-3">
-  <h1 class="text-center mb-4"><%= t('defaults.signup') %></h1>  
+  <h1 class="text-center mb-4"><%= t('.title') %></h1>  
   <%= form_with model: @user, local: true do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="mb-3">

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,7 @@ module MusicMemory
         view_specs: false,
         helper_specs: false,
         controller_specs: false,
-        routing_specs: false,
-        request_specs: false
+        routing_specs: false
     end
 
     config.time_zone = 'Asia/Tokyo'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: "ユーザー"
+      post: "投稿"
     attributes:
       user:
         name: "名前"
@@ -10,6 +11,9 @@ ja:
         gender: "性別"
         password: "パスワード"
         password_confirmation: "パスワード確認"
+      post:
+        music_name: "曲名"
+        memory: "曲の感想や思い出"
   attributes:
     created_at: "作成日"
     updated_at: "更新日"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
     login: "ログイン"
     signup: "新規登録"
     logout: "ログアウト"
+    contributor: "投稿者"
     messages:
       not_authenticated: "ログインしてください"
       login_success: "ログインしました"
@@ -10,12 +11,22 @@ ja:
       logout_success: "ログアウトしました"
       signup_success: "登録完了しました"
       signup_failed: "もう一度お願いします"
+      post_create_success: "曲の思い出を投稿しました"
+      post_create_failed: "投稿に失敗しました"
+      login_limited: "アクセスできません"
   users:
     new:
-      title: "ユーザー登録"
+      title: "新規登録"
       to_login_page: "ログインページはこちら"
   user_sessions:
     new:
       title: "ログイン"
       to_signup_page: "新規登録はこちら"
       password_forget: "パスワードをお忘れの方はこちら"
+  posts:
+    index:
+      title: "投稿一覧"
+    new:
+      title: "新規投稿"
+    show:
+      title: "投稿詳細"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
-  root "users#index"
+  root "posts#index"
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
-  resources :users
+  resources :users, only: %i[index new create destroy]
+  resources :posts, only: %i[index new create show]
 end

--- a/db/migrate/20231115113357_create_embeds.rb
+++ b/db/migrate/20231115113357_create_embeds.rb
@@ -1,0 +1,10 @@
+class CreateEmbeds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :embeds do |t|
+      t.integer :embed_type
+      t.string :identifer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231115121801_create_posts.rb
+++ b/db/migrate/20231115121801_create_posts.rb
@@ -1,0 +1,14 @@
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.string :music_name
+      t.text :memory
+      t.references :user, null: false, foreign_key: true
+      t.references :embed, foreign_key: true
+      t.integer :age_group
+      t.integer :prefecture_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231118034241_change_columns_not_null_add_posts.rb
+++ b/db/migrate/20231118034241_change_columns_not_null_add_posts.rb
@@ -1,0 +1,6 @@
+class ChangeColumnsNotNullAddPosts < ActiveRecord::Migration[7.0]
+  def change
+    change_column :posts, :music_name, :string, null: false
+    change_column :posts, :memory, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_08_140830) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_18_034241) do
+  create_table "embeds", force: :cascade do |t|
+    t.integer "embed_type"
+    t.string "identifer"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "music_name", null: false
+    t.string "memory", null: false
+    t.integer "user_id", null: false
+    t.integer "embed_id"
+    t.integer "age_group"
+    t.integer "prefecture_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["embed_id"], name: "index_posts_on_embed_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -27,4 +47,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_08_140830) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "posts", "embeds"
+  add_foreign_key "posts", "users"
 end

--- a/spec/factories/embeds.rb
+++ b/spec/factories/embeds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :embed do
+    embed_type { 1 }
+    identifer { "MyString" }
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :post do
+    sequence(:music_name) { |n| "My Music Name-#{n}" }
+    sequence(:memory) { |n| "My Memory-#{n}" }
+    association :user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name { Faker::Name.unique.name }
-    email { Faker::Internet.unique.free_email }
+    email { Faker::Internet.unique.email }
     password { 'password' }
     password_confirmation { 'password' }
   end

--- a/spec/models/embed_spec.rb
+++ b/spec/models/embed_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Embed, type: :model do
+  
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  let(:user) { create(:user) }
+  it '曲名、思い出がある場合、有効' do
+    post = Post.new(
+      music_name: "好きな音楽",
+      memory: "聞いた時の感想",
+      user_id: user.id
+    )
+    expect(post).to be_valid
+  end
+  it '曲名がない時、無効' do
+    post = Post.new(
+      music_name: "",
+      memory: "聞いた時の感想",
+      user_id: user.id
+    )
+    expect(post).to be_invalid
+  end
+  it '思い出がない時、無効' do
+    post = Post.new(
+      music_name: "好きな音楽",
+      memory: "",
+      user_id: user.id
+    )
+    expect(post).to be_invalid
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :model do
-  it 'userのvalidationについて' do
-    user = build(:user)
+  let!(:first_user) { create(:user, email: "example@example.com") }
+  it '名前、メール、パスワード、パスワード確認がある場合、有効' do
+    user = User.new(
+      name: "tanaka tarou",
+      email: "tarou@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
     expect(user).to be_valid
+  end
+  it '名前がない場合、無効' do
+    user = User.new(
+      name: "",
+      email: "tarou@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
+    expect(user).to be_invalid
+  end
+  it 'メールアドレスがない場合、無効' do
+    user = User.new(
+      name: "tanaka tarou",
+      email: "",
+      password: "password",
+      password_confirmation: "password"
+    )
+    expect(user).to be_invalid
+  end
+  it '重複したメールアドレスの場合、無効' do
+    user2 = User.new(
+      name: "tanaka tarou",
+      email: "example@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
+    expect(user2).to be_invalid
+  end
+  it 'パスワードがない場合、無効' do
+    user = User.new(
+      name: "tanaka tarou",
+      email: "tarou@example.com",
+      password: "",
+      password_confirmation: "password"
+    )
+    expect(user).to be_invalid
+  end
+  it 'パスワード確認がない場合、無効' do
+    user = User.new(
+      name: "tanaka tarou",
+      email: "tarou@example.com",
+      password: "password",
+      password_confirmation: ""
+    )
+    expect(user).to be_invalid
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include LoginModule
+  config.include Sorcery::TestHelpers::Rails::Request, type: :request
 end

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "UserSessions", type: :request do
+  describe 'GET /new' do
+    context 'logging in' do
+      let!(:user) { create(:user) }
+      before { login_user(user, 'password', login_path) }
+      it 'returns http success' do
+        get login_path
+        expect(response).to redirect_to root_path
+      end
+    end
+    context 'not logged in' do
+      it 'returns http failed' do
+        get login_path
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  describe 'GET /index' do
+    context 'logging in' do
+      let!(:user) { create(:user) }
+      before { login_user(user, 'password', login_path) }
+      it 'returns http success' do
+        get users_path
+        expect(response).to have_http_status(200)
+      end
+    end
+    context 'not logged in' do
+      it 'returns http failed' do
+        get users_path
+        expect(response).to_not have_http_status(200)
+      end
+    end
+  end
+
+  describe 'GET /signup' do
+    context 'logging in' do
+      let!(:user) { create(:user) }
+      before { login_user(user, 'password', login_path) }
+      it 'returns http success' do
+        get signup_path
+        expect(response).to redirect_to root_path
+      end
+    end
+    context 'not logged in' do
+      it 'returns http failed' do
+        get signup_path
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium, using: :chrome, screen_size: [540, 540]
+    driven_by :rack_test
+    #driven_by :selenium, using: :chrome, screen_size: [540, 540]
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :system do
+  describe '投稿一覧' do
+    context '投稿が存在しない' do
+      before do
+        visit posts_path
+      end
+      it '画面には投稿が存在しないという文が表示される' do
+        expect(page).to have_content("投稿はありません")
+      end
+    end
+    context '投稿が存在する' do
+      let!(:user1) { create(:user) }
+      let!(:user2) { create(:user) }
+      let!(:post1) { create(:post, user_id: user1.id) }
+      before do
+        login(user2)
+        visit posts_path
+      end
+      it '投稿曲名が表示される' do
+        expect(page).to have_content(post1.music_name)
+      end
+      it '思い出が表示される' do
+        expect(page).to have_content(post1.memory)
+      end
+      it '投稿者名が表示される' do
+        expect(page).to have_content(post1.user.name)
+      end
+    end
+  end
+
+  describe '新規投稿' do
+    let!(:user) { create(:user) }
+    before do
+      login(user)
+      visit new_post_path
+    end
+    context '正常系' do
+      it '新規投稿ページから投稿できる' do
+        fill_in Post.human_attribute_name(:music_name), with: 'music!'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
+        expect{find('input[name="commit"]').click}.to change{ Post.count }.by(1)
+      end
+      it '投稿後に投稿一覧に遷移した際投稿が反映されている' do
+        fill_in '曲名', with: 'music!'
+        fill_in '曲の感想や思い出', with: 'memory!'
+        find('input[name="commit"]').click
+        expect(page).to have_content('memory!')
+      end
+    end
+    context '異常系' do
+      it '空欄で投稿した時フラッシュメッセージが出て失敗する' do
+        find('input[name="commit"]').click
+        expect(page).to have_content(I18n.t('defaults.messages.post_create_failed'))
+      end
+    end
+  end
+
+  describe '投稿詳細' do
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:post_show) { create(:post, user: user2, music_name: "あああ") }
+    before do
+      post_list = create_list(:post, 5)
+      login(user1)
+      visit posts_path
+    end
+    it '投稿一覧からリンクを押して詳細画面に移動できる' do
+      click_on post_show.music_name
+      expect(page).to have_content(post_show.music_name)
+      expect(page).to have_content(post_show.memory)
+      expect(page).to have_content(post_show.user.name)
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -5,36 +5,24 @@ RSpec.describe "Users", type: :system do
     context '正常系' do
       it 'Userを新規作成できる' do
         visit root_path
-        expect(page).to have_content('新規登録')
-        click_link '新規登録'
-        fill_in '名前', with: Faker::Name.unique.name
-        fill_in 'メールアドレス', with: Faker::Internet.unique.free_email
-        fill_in 'パスワード', with: 'password'
-        fill_in 'パスワード確認', with: 'password'
+        expect(page).to have_content(I18n.t('defaults.signup'))
+        click_link I18n.t('defaults.signup')
+        fill_in User.human_attribute_name(:name), with: Faker::Name.unique.name
+        fill_in User.human_attribute_name(:email), with: Faker::Internet.unique.email
+        fill_in User.human_attribute_name(:password), with: 'password'
+        fill_in User.human_attribute_name(:password_confirmation), with: 'password'
         expect{find('input[name="commit"]').click}.to change{ User.count }.by(1)
       end
     end
     context '異常系' do
-      describe '' do
-        before do
-          visit signup_path
-        end
-        let!(:user1) { create(:user) }
-        it 'カラム未記入では新規登録できない' do
-          find('input[name="commit"]').click
-          expect(page).to have_content('新規登録')
-          expect( User.count ).to eq 1
-          expect(page).to have_content('もう一度お願いします')
-        end
-        it 'emailがすでに存在しているとき新規登録できない' do
-          fill_in '名前', with: Faker::Name.unique.name
-          fill_in 'メールアドレス', with: user1.email
-          fill_in 'パスワード', with: 'password'
-          fill_in 'パスワード確認', with: 'password'
-          find('input[name="commit"]').click
-          expect( User.count ).to eq 1
-          expect(page).to have_content('メールアドレスはすでに存在します')
-        end
+      before do
+        visit signup_path
+      end
+      let!(:user1) { create(:user) }
+      it 'カラム未記入では新規登録できない' do
+        expect{find('input[name="commit"]').click}.to change{User.count}.by(0)
+        expect(page).to have_content(I18n.t('users.new.title'))
+        expect(page).to have_content(I18n.t('defaults.messages.signup_failed'))
       end
     end
   end
@@ -46,16 +34,16 @@ RSpec.describe "Users", type: :system do
     let!(:user) { create(:user) }
     context '正常系' do
       it 'ログイン成功' do
-        fill_in 'メールアドレス', with: user.email
-        fill_in 'パスワード', with: 'password'
+        fill_in User.human_attribute_name(:email), with: user.email
+        fill_in User.human_attribute_name(:password), with: 'password'
         find('input[name="commit"]').click
         expect(page).to have_content(user.name)
       end
     end
     context '異常系' do
-      it '新規登録ボタンを押すとログインページへ遷移' do
+      it '空欄のまま新規登録ボタンを押すとログインページへフラッシュメッセージと共に戻される' do
         find('input[name="commit"]').click
-        expect(page).to have_content('ログインに失敗しました')
+        expect(page).to have_content(I18n.t('defaults.messages.login_failed'))
       end
     end
   end
@@ -64,8 +52,8 @@ RSpec.describe "Users", type: :system do
     let!(:user) { create(:user) }
     it 'ログアウト成功' do
       login(user)
-      click_on 'ログアウト'
-      expect(page).to have_content('ログアウトしました')
+      click_on I18n.t('defaults.logout')
+      expect(page).to have_content(I18n.t('defaults.messages.logout_success'))
     end
   end
 end


### PR DESCRIPTION
今回のコミットでは投稿に関して、music_nameとmemoryのカラムのみを投稿することができるようにしています。できることとしてはpostsに関してindex,new,create,showに関して最低限できるようになっています。以下の項目が今回のコミットで実装した内容です。

1.埋め込み動画に関するembedsテーブルを作成しました。
2.postsテーブルの作成を行いました。
3.prefectureモデルを作成しました。prefectureモデルに関しては出身県とそれぞれの曲を聞いた土地に関して使用するのでactive_hashのgemを使用して必要なテーブルでprefecture_idの形で使用できるようにしたためテーブルは作成していませんがpostとuserのカラムにはprefecture_idが設定されています。
4.今回の実装では投稿自体はmusic_nameとmemoryのカラムしか使用しないですが、使用するための内容(age_groupの曲を聞いた年代についてとactive_hashを使用するための記述)はモデル内に記述しています。
5.fakerにおいて非推奨であった記述を変更しました(Faker::Internet.free_email→Faker::Internet.email)。
6.loginページとsignupページとそれぞれで行われるログインと新規登録機能が制限されるようにusers_controllerとuser_sessions_controllerでlogin_limitedのメソッドを作成しました。
7.ルーティングにおいてrootをposts#indexのものへ変更、resourcesのusersとpostsに対してアクションを制限しました。
8.modelスペックに書くべき内容をsystemディレクトリ下に記述していたのでそちらに移動しました。
9.後付けでpostsへnot null制約を付与しました。
10.system/posts_spec.rbへindex,new,create,showのテストを記述しました。
11.system/users_spec.rbへ新規登録のrspecのテストで不要な記述(describeで無駄な囲いが一つありました)を削除しました。
12.今後カラム名やタイトルなどが変更される時にも対応できるようにsystem/users_spec.rbにおいて、i18nで表すことのできる記述へ変更しました。
13.models/post_spec.rbとuser_spec.rbでvalidationのテストを記述しました。
14.userとpostのrequestスペックを記述しました。そのためにconfig/application.rbへのrspecでrequestを作成しないように設定した内容を削除しました。また、requestスペックで使用するためにspecs/rails_helper.rbへsorceryのtesthelperをincludeしました。

以下にテストに関するスクリーンショットを貼り付けます。
[![Image from Gyazo](https://i.gyazo.com/e83b7e4f6e64ae9ef726397e29b8fe88.png)](https://gyazo.com/e83b7e4f6e64ae9ef726397e29b8fe88)
[![Image from Gyazo](https://i.gyazo.com/5217b168dfe4e13079749446de975429.png)](https://gyazo.com/5217b168dfe4e13079749446de975429)