### PR TITLE
Add:新規投稿で曲を聞いた年代、聞いた地域、曲のURLを入れて埋め込み動画を一緒に投稿することができるようにしました

### DIFF
--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -1,5 +1,40 @@
 class Embed < ApplicationRecord
   has_many :posts, dependent: :destroy
-  
+
   enum embed_type: { youtube: 0, apple_music: 1, spotify: 2}
+
+  def embed_judge
+    if self.embed_type.blank? || self.identifer.blank?
+      self.embed_type = ""
+      self.identifer = ""
+    else
+      if self.youtube?
+        self.identifer = youtube_identifer
+      elsif self.apple_music?
+        self.identifer = apple_music_identifer
+      elsif self.spotify?
+        self.identifer = spotify_music_identifer
+      else
+        self.embed_type = ""
+        self.identifer = ""
+      end
+    end
+  end
+  
+  def youtube_identifer
+    string_identifer = identifer.split('/').last
+    if string_identifer.include?("watch?v=")
+      string_identifer[8, 11]
+    else
+      string_identifer[0, 11]
+    end
+  end
+  
+  def apple_music_identifer
+    identifer.split('/').last(2).join('/')
+  end
+  
+  def spotify_music_identifer
+    identifer.split('/').last[0, 22]
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
-  #belongs_to :embed
+  belongs_to :embed
   
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,14 +1,32 @@
-<%= form_with model: post, class: "offset-md-1 offset-lg-2 col-md-10 col-lg-8", local: true do |f| %>
+<%= form_with model: post, class: "offset-lg-1 col-lg-10", local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="mb-3">
     <%= f.label :music_name %><br />
-    <%= f.text_field :music_name, class: "form-control", placeholder: "曲名", value: post.music_name %>
+    <%= f.text_field :music_name, class: "form-control", placeholder: Post.human_attribute_name(:music_name), value: post.music_name %>
   </div>
   <div class="mb-3">
     <%= f.label :memory %><br />
-    <%= f.text_area :memory, class: "form-control", placeholder: "あなたのこの曲の思い出を書きましょう", value: post.memory %>
+    <%= f.text_area :memory, class: "form-control", placeholder: t('defaults.messages.memory_placeholder'), value: post.memory %>
   </div>
+  <div class="mb-3">
+    <%= f.label :age_group %><br />
+    <%= f.select :age_group, Post.age_groups_i18n.keys.map {|k| [Post.age_groups_i18n[k], k]}, { include_blank: t('defaults.messages.age_group_placeholder') }, class: "form-control" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :prefecture_id %><br />
+    <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, class: "form-control" %>
+  </div>
+  <%= f.fields_for embed do |embed_form| %>
+    <div class="mb-3">
+      <%= embed_form.label :embed_type %><br />
+      <%= embed_form.select :embed_type, Embed.embed_types_i18n.keys.map { |k| [Embed.embed_types_i18n[k], k]}, {include_blank: "---"}, class: "form-control", selected: embed.embed_type_i18n %><br />
+    </div>
+    <div class="mb-3">
+      <%= embed_form.label :identifer %><br />
+      <%= embed_form.text_field :identifer, class: "form-control", placeholder: t('posts.new.embed_identifer_content'), value: embed.identifer %><br />
+    </div>
+  <% end %>
   <div class="mb-3 text-center mt-4">
-    <%= f.submit "投稿", class:"btn btn-primary w-50" %>
+    <%= f.submit t('posts.new.submit'), class:"btn btn-primary w-50" %>
   </div>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,14 +1,16 @@
-<div class="card p-3">
-  <table>
-    <div><%= link_to post.music_name, post_path(post), class: "fs-2" %></div>
-    <tr>
-      <td><%= Post.human_attribute_name(:memory) %></td>
-      <td><%= post.memory %></td>
-    </tr>
-    <tr>
-      <td><%= t('defaults.contributor') %></td>
-      <td><%= post.user.name %></td>
-    </tr>
-  </table>
-  <%= render 'crud_menu', post: post %>
+<div class="container">
+  <div class="row">
+    <div class="card p-4">
+      <table>
+        <tr><td><%= link_to post.music_name, post_path(post), class: "fs-2" %></td></tr>
+        <tr><td><%= post.memory %></td></tr>
+        <tr><td><%= post.age_group_i18n %></td></tr>
+        <% if post.prefecture.present? %>
+          <tr><td><%= post.prefecture.name %></td></tr>
+        <% end %>
+        <tr><td><%= link_to "#{t('defaults.contributor')}: #{post.user.name}", user_path(post.user) %></td></tr>
+      </table>
+      <%= render 'crud_menu', post: post %>
+    </div>
+  </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,7 @@
       <% if @posts.present? %>
         <%= render @posts %>
       <% else %>
-        <div>投稿はありません</div>
+        <div><%= t('defaults.messages.no_posts') %></div>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:title, t('.title')) %>
-<div class="form-signin m-auto col-6 offset-3">
+<div class="form-signin m-auto col-7 offset-2">
   <h1 class="text-center mb-4"><%= t('.title') %></h1>  
-  <%= render 'form', post: @post %>
+  <%= render 'form', post: @post, embed: @embed %>
   <div class="text-center">
-    <%= link_to '戻る', posts_path %>
+    <%= link_to t('defaults.back_button'), posts_path %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,10 +1,27 @@
 <% content_for(:title, "#{Post.human_attribute_name(:music_name)}:#{@post.music_name}") %>
 <div class="col-8 offset-2">
-  <h1 class="mt-4 mb-4"><%= t('.title') %></h1>
+  <h1 class="pb-4 pt-4"><%= t('.title') %></h1>
+  <div class="text-center">
+    <% if !@post.embed.identifer.empty? %>
+      <% if @post.embed.youtube? %>
+        <%= content_tag 'iframe', nil, width: '100%', height: '350px', src: "https://www.youtube.com/embed/#{@post.embed.identifer}", frameborder: 0, allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture", style: "max-width:600px;", allowfullscreen: "" %>
+      <% elsif @post.embed.apple_music? %>
+        <%= content_tag 'iframe', nil, allow: "autoplay; encrypted-media *; fullscreen *; clipboard-write; picture-in-picture", frameborder: "0", height: "200px", style: "width:100%;max-width:600px;", sandbox: "allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation", src: "https://embed.music.apple.com/jp/album/#{@post.embed.identifer}" %>
+      <% elsif @post.embed.spotify? %>
+        <%= content_tag 'iframe', nil, allow: "autoplay; encrypted-media *; fullscreen *; clipboard-write; picture-in-picture",loading: "lazy", frameborder: "0", height: "200px", style: "width:100%;max-width:660px;overflow:hidden;border-radius:10px;max-width:600px;", src: "https://open.spotify.com/embed/track/#{@post.embed.identifer}?utm_source=generator" %>
+      <% end %>
+      <p><%= @post.embed.embed_type_i18n %></p>
+      <p><%= @post.embed.identifer %></p>
+    <% end %>
+  </div>
   <table class="table table-light">
     <tr>
       <th><%= t('defaults.contributor') %></th>
-      <td><%= @post.user.name %></td>
+      <% if current_user.mine?(@post) %>
+        <td><%= @post.user.name %></td>
+      <% else %>
+        <td><%= link_to @post.user.name, user_path(@post.user) %></td>
+      <% end %>
     </tr>
     <tr>
       <th><%= Post.human_attribute_name(:music_name) %></th>
@@ -14,6 +31,12 @@
       <th><%= Post.human_attribute_name(:memory) %></th>
       <td><%= @post.memory %></td>
     </tr>
+    <% if @post.prefecture.present? %>
+      <tr>
+        <th><%= Post.human_attribute_name(:prefecture_id) %></th>
+        <td><%= @post.prefecture.name %></td>
+      </tr>
+    <% end %>
   </table>
   <%= render 'crud_menu', post: @post %>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -5,5 +5,5 @@
         <li><%= msg %></li>
       <% end %>
     </ul>
-    </div>
+  </div>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
             <% end %>
           </li>
           <li class="nav-item"><%= link_to "Mypage", '#', class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to "新規投稿", new_post_path, class: "nav-link" %></li>
+          <li class="nav-item"><%= link_to t('defaults.new_post'), new_post_path, class: "nav-link" %></li>
           <li class="nav-item"><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "nav-link" %></li>
         <% else %>
           <li class="nav-item"><%= link_to "Home", '#', class: "nav-link" %></li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,5 +2,7 @@
 <% if @users.present? %>
   <%= render @users %>
 <% else %>
-  ユーザーが存在しません。
+  <div>
+    <%= t('defaults.messages.no_users') %>
+  </div>
 <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,6 +14,11 @@ ja:
       post:
         music_name: "曲名"
         memory: "曲の感想や思い出"
+        age_group: "聞いた年代"
+        prefecture_id: "聞いた都道府県"
+      embed:
+        embed_type: "動画タイプ"
+        identifer: "動画のURL"
   attributes:
     created_at: "作成日"
     updated_at: "更新日"
@@ -23,3 +28,27 @@ ja:
         other: "その他"
         male: "男性"
         female: "女性"
+    post:
+      age_group:
+        childhood: "幼少期"
+        elementary: "小学生時代"
+        middle: "中学時代"
+        high: "高校時代"
+        early_20s: "大学時代~20代前半"
+        late_20s: "25~29歳"
+        early_30s: "30~34歳"
+        late_30s: "35~39"
+        early_40s: "40~44歳"
+        late_40s: "45~49歳"
+        early_50s: "50~54歳"
+        late_50s: "55~59歳"
+        early_60s: "60~64歳"
+        late_60s: "65~69歳"
+        early_70s: "70~74歳"
+        late_70s: "75~79歳"
+    embed:
+      embed_type:
+        youtube: "YouTube"
+        apple_music: "Apple Music"
+        spotify: "Spotify"
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,8 @@ ja:
     signup: "新規登録"
     logout: "ログアウト"
     contributor: "投稿者"
+    back_button: "戻る"
+    new_post: "新規投稿"
     messages:
       not_authenticated: "ログインしてください"
       login_success: "ログインしました"
@@ -14,6 +16,13 @@ ja:
       post_create_success: "曲の思い出を投稿しました"
       post_create_failed: "投稿に失敗しました"
       login_limited: "アクセスできません"
+      post_success: "投稿しました"
+      post_failed: "投稿に失敗しました"
+      embed_lacking: "動画タイプとURLを両方入力してください"
+      memory_placeholder: "あなたのこの曲の思い出を書きましょう"
+      age_group_placeholder: "聴いた年代を選択してください"
+      no_posts: "投稿はありません"
+      no_users: "ユーザーが存在しません"
   users:
     new:
       title: "新規登録"
@@ -28,5 +37,7 @@ ja:
       title: "投稿一覧"
     new:
       title: "新規投稿"
+      embed_identifer_content: "直接URLまたは共有ボタンのリンクを貼ってください"
+      submit: "投稿"
     show:
       title: "投稿詳細"

--- a/spec/factories/embeds.rb
+++ b/spec/factories/embeds.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :embed do
-    embed_type { 1 }
-    identifer { "MyString" }
+    embed_type { 0 }
+    identifer { "aBu9LDKZIF4" }
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -2,6 +2,9 @@ FactoryBot.define do
   factory :post do
     sequence(:music_name) { |n| "My Music Name-#{n}" }
     sequence(:memory) { |n| "My Memory-#{n}" }
+    prefecture_id { 1 }
+    age_group { 0 }
     association :user
+    association :embed
   end
 end

--- a/spec/models/embed_spec.rb
+++ b/spec/models/embed_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Embed, type: :model do
-  
-end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Post, type: :model do
   let(:user) { create(:user) }
+  let(:embed) { create(:embed) }
   it '曲名、思い出がある場合、有効' do
     post = Post.new(
       music_name: "好きな音楽",
       memory: "聞いた時の感想",
-      user_id: user.id
+      user_id: user.id,
+      embed_id: embed.id
     )
     expect(post).to be_valid
   end
@@ -14,7 +16,8 @@ RSpec.describe Post, type: :model do
     post = Post.new(
       music_name: "",
       memory: "聞いた時の感想",
-      user_id: user.id
+      user_id: user.id,
+      embed_id: embed.id
     )
     expect(post).to be_invalid
   end
@@ -22,7 +25,8 @@ RSpec.describe Post, type: :model do
     post = Post.new(
       music_name: "好きな音楽",
       memory: "",
-      user_id: user.id
+      user_id: user.id,
+      embed_id: embed.id
     )
     expect(post).to be_invalid
   end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe "Posts", type: :system do
         expect{find('input[name="commit"]').click}.to change{ Post.count }.by(1)
       end
       it '投稿後に投稿一覧に遷移した際投稿が反映されている' do
-        fill_in '曲名', with: 'music!'
-        fill_in '曲の感想や思い出', with: 'memory!'
+        fill_in Post.human_attribute_name(:music_name), with: 'music!'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
         find('input[name="commit"]').click
         expect(page).to have_content('memory!')
       end
@@ -53,6 +53,86 @@ RSpec.describe "Posts", type: :system do
       it '空欄で投稿した時フラッシュメッセージが出て失敗する' do
         find('input[name="commit"]').click
         expect(page).to have_content(I18n.t('defaults.messages.post_create_failed'))
+      end
+    end
+  end
+
+  describe '動画タイプと動画のURLに関しての新規投稿後' do
+    let!(:user) { create(:user) }
+    before do
+      login(user)
+      visit new_post_path
+    end
+    context '動画タイプまたは動画URLのどれかにおいて空欄の場合' do
+      it '動画タイプのみ空欄で動画URLが入力されている時iframeは表示されない' do
+        fill_in Post.human_attribute_name(:music_name), with: 'musicnomemory'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
+        find("#post_age_group").find("option[value='elementary']").select_option
+        find("#post_prefecture_id").find("option[value='10']").select_option
+        fill_in Embed.human_attribute_name(:identifer), with: 'https://www.youtube.com/watch?v=C-o8pTi6vd8&list=PLGAJbrONUQc_l3zZMKsbWqnd-af7psPqT&index=146'
+        find('input[name="commit"]').click
+        expect(page).to have_content('musicnomemory')
+        click_on 'musicnomemory'
+        expect(page).to_not have_selector 'iframe', wait: 5
+      end
+      it '動画URLのみ空欄で動画タイプが入力されている時iframeは表示されない' do
+        fill_in Post.human_attribute_name(:music_name), with: 'musicnomemory'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
+        find("#post_age_group").find("option[value='elementary']").select_option
+        find("#post_prefecture_id").find("option[value='10']").select_option
+        find("#post_embed_embed_type").find("option[value='youtube']").select_option
+        find('input[name="commit"]').click
+        expect(page).to have_content('musicnomemory')
+        click_on 'musicnomemory'
+        expect(page).to_not have_selector 'iframe', wait: 5
+      end
+      it '動画タイプと動画URLが両方空欄の時iframeは表示されない' do
+        fill_in Post.human_attribute_name(:music_name), with: 'musicnomemory'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
+        find("#post_age_group").find("option[value='elementary']").select_option
+        find("#post_prefecture_id").find("option[value='10']").select_option
+        find('input[name="commit"]').click
+        expect(page).to have_content('musicnomemory')
+        click_on 'musicnomemory'
+        expect(page).to_not have_selector 'iframe', wait: 5
+      end
+    end
+    context '動画タイプと動画URLが両方存在している場合' do
+      it 'iframeが表示される(youtube)' do
+        fill_in Post.human_attribute_name(:music_name), with: '狂乱Hey Kids!!'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
+        find("#post_age_group").find("option[value='elementary']").select_option
+        find("#post_prefecture_id").find("option[value='10']").select_option
+        find("#post_embed_embed_type").find("option[value='youtube']").select_option
+        fill_in Embed.human_attribute_name(:identifer), with: 'https://www.youtube.com/watch?v=C-o8pTi6vd8&list=PLGAJbrONUQc_l3zZMKsbWqnd-af7psPqT&index=146'
+        find('input[name="commit"]').click
+        expect(page).to have_content('狂乱Hey Kids!!')
+        click_on '狂乱Hey Kids!!'
+        expect(page).to have_selector 'iframe', wait: 5
+      end
+      it 'iframeが表示される(apple_music)' do
+        fill_in Post.human_attribute_name(:music_name), with: 'さくらんぼ'
+        fill_in Post.human_attribute_name(:memory), with: 'memory!'
+        find("#post_age_group").find("option[value='elementary']").select_option
+        find("#post_prefecture_id").find("option[value='10']").select_option
+        find("#post_embed_embed_type").find("option[value='apple_music']").select_option
+        fill_in Embed.human_attribute_name(:identifer), with: 'https://music.apple.com/jp/album/%E3%81%95%E3%81%8F%E3%82%89%E3%82%93%E3%81%BC/76106703?i=76106271'
+        find('input[name="commit"]').click
+        expect(page).to have_content('さくらんぼ')
+        click_on 'さくらんぼ'
+        expect(page).to have_selector 'iframe', wait: 5
+      end
+      it 'iframeが表示される(spotify)' do
+        fill_in Post.human_attribute_name(:music_name), with: 'girlfriend'
+        fill_in Post.human_attribute_name(:memory), with: 'musicnomemory'
+        find("#post_age_group").find("option[value='elementary']").select_option
+        find("#post_prefecture_id").find("option[value='10']").select_option
+        find("#post_embed_embed_type").find("option[value='spotify']").select_option
+        fill_in Embed.human_attribute_name(:identifer), with: 'https://open.spotify.com/intl-ja/artist/0p4nmQO2msCgU4IF37Wi3j'
+        find('input[name="commit"]').click
+        expect(page).to have_content('girlfriend')
+        click_on 'girlfriend'
+        expect(page).to have_selector 'iframe', wait: 5
       end
     end
   end
@@ -71,6 +151,7 @@ RSpec.describe "Posts", type: :system do
       expect(page).to have_content(post_show.music_name)
       expect(page).to have_content(post_show.memory)
       expect(page).to have_content(post_show.user.name)
+      expect(page).to have_selector 'iframe', wait: 5
     end
   end
 end


### PR DESCRIPTION
Add: 新規投稿で曲を聞いた年代、地域、その曲の動画タイプ(YouTube,AppleMusic,Spotifyでそれぞれ選べます)、動画の共有リンクもしくはURLを直接入れていただくことで投稿詳細画面でその埋め込み動画の視聴も可能にしました。

1.埋め込み動画を新規投稿で曲名と一緒に投稿できるようにposts_controllerを変更しました。
2.models/embed.rbへ埋め込み動画のタイプ(embed_typeをenumでそれぞれyoutube,apple_music,spotify)を選べるようにし、それぞれで埋め込みに必要な部分のみを文字列としてidentiferカラムで保存できるようにしました。
3.新規投稿で投稿できるようになった内容として、曲を聞いた地域のprefecture_id、年代のage_group(postでenumを使用しています)、埋め込み動画のタイプについてのembedモデルからembed_type、埋め込み動画のURL(共有からのリンクやそのままURLでも可能)のembedのidentiferを実装しました。
4.投稿詳細でembedのidentifer(埋め込み動画の固有文字列部分)に値がある時、つまり新規投稿時にembed_typeもしくはidentiferのどちらも記入されている時(備考を参照)、動画が表示されるようにしました。
5.modelsとsystemの投稿に関するrspecを作成し、factorybotのembedとpostに関するものを編集しテストしました。現在は最低限の内容なので、今後必要であればそちらの内容も変更しようと思います。
6.日本語化対応にしていない記述を修正しました。

[備考]
動画が存在しない場合、または曲名と感想のみを求めて動画を添付しないUserの場合を考えてembedの動画タイプと動画URLはnot null制約をつけませんでした。しかし、動画タイプと動画URLを後から編集できることを考えるとどちらかが空の時どちらも空白にする(固有の文字列を切り取って保存しているためどの動画タイプかわからない時保存の使用がないため)方法にしました。今後よりいい方法が出るかもしれませんが、現在はひとまずembedはどちらかが空の時はどちらも空で保存される形式をとっています。