### PR TITLE
Add: 検索機能とページネーション機能の基礎を実装しました

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
   add_flash_types :success, :info, :warning, :danger
+  before_action :set_q
+  
+  def set_q
+    @q = Post.ransack(params[:q].try(:merge, m: 'or'))
+  end
 
   private
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
 
   def index
-    @posts = Post.all.includes(:user).order(created_at: :desc)
+    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page]).per(10)
   end
 
   def new

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,4 +27,12 @@ class Post < ApplicationRecord
                     early_70s: 70,
                     late_70s: 75,
                   }
+  
+  def self.ransackable_attributes(auth_object = nil)
+    ["age_group", "created_at", "embed_id", "memory", "music_name", "prefecture_id", "user_id"]
+  end
+  
+  def self.ransackable_associations(auth_object = nil)
+    ["comments", "embed", "like_users", "likes", "prefecture", "user"]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,8 @@ class User < ApplicationRecord
   mount_uploader :avatar, AvatarUploader
   enum gender: {other: 0 , male: 1, female: 2}
 
-  def profile_x_id
-    
+  def self.ransackable_attributes(auth_object = nil)
+    ['name']
   end
 
   def mine?(object)

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,5 +9,6 @@
         <div><%= t('defaults.messages.no_posts') %></div>
       <% end %>
     </div>
+    <%= paginate @posts, theme: 'bootstrap-5' %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,12 @@
         <svg class="bi me-2" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
         <h1 class="fs-2">Music Memory</h1>
       <% end %>
-      
+
+      <%= search_form_for @q, url: posts_path, class: "col-lg-auto mt-1 mb-lg-0 me-lg-3 text-bottom" do |f| %>
+        <%= f.search_field :music_name_or_memory_or_user_name_cont, placeholder: "Search..." %>
+        <%= f.submit t('defaults.search') %>
+      <% end %>
+            
       <ul class="nav nav-pills">
         <% if logged_in? %>
           <li class="nav-item"><%= link_to "About", '#', class: "nav-link" %></li>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -11,7 +11,7 @@
       <%= f.password_field :password, class: "form-control", placeholder: "password" %>
     </div>
     <div class="mb-3 text-center mt-4">
-      <%= f.submit t('defaults.login'), class:"btn btn-primary w-50" %>
+      <%= f.submit t('.submit'), class:"btn btn-primary w-50" %>
     </div>
   <% end %>
   <div class="text-center">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,7 +20,7 @@
       <%= f.password_field :password_confirmation, class: "form-control", placeholder: "password" %>
     </div>
     <div class="mb-3 text-center mt-4">
-      <%= f.submit t('defaults.signup'), class:"btn btn-primary w-50" %>
+      <%= f.submit t('.submit'), class:"btn btn-primary w-50" %>
     </div>
   <% end %>
   <div class="text-center">

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
     back_button: "戻る"
     new_post: "新規投稿"
     mypage: "マイページ"
+    search: "検索"
     messages:
       not_authenticated: "ログインしてください"
       login_success: "ログインしました"
@@ -33,12 +34,14 @@ ja:
   users:
     new:
       title: "新規登録"
+      submit: "新規登録する"
       to_login_page: "ログインページはこちら"
     show:
       title: "%{user}さん"
   user_sessions:
     new:
       title: "ログイン"
+      submit: "ログインする"
       to_signup_page: "新規登録はこちら"
       password_forget: "パスワードをお忘れの方はこちら"
   posts:

--- a/spec/support/login_module.rb
+++ b/spec/support/login_module.rb
@@ -3,6 +3,7 @@ module LoginModule
     visit login_path
     fill_in 'メールアドレス', with: user.email
     fill_in 'パスワード', with: 'password'
-    find('input[name="commit"]').click
+    #find(I18n.t('user_sessions.new.submit')).click
+    click_on I18n.t('user_sessions.new.submit')
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -31,6 +31,46 @@ RSpec.describe "Posts", js: true, type: :system do
         end
       end
     end
+    describe '検索機能' do
+      let!(:first_user) { create(:user, name: "first-second") }
+      let!(:second_user) { create(:user, name: "sec-ird") }
+      let!(:third_user) { create(:user, name: "third-ec") }
+      let!(:post_fu_1) { create(:post, music_name: "aaaaa-music", user_id: first_user.id)}
+      let!(:post_fu_2) { create(:post, music_name: "bbbbb-music", user_id: first_user.id)}
+      let!(:post_su_2) { create(:post, music_name: "aaa-music", user_id: second_user.id)}
+      let!(:post_tu_1) { create(:post, music_name: "ec-music", user_id: third_user.id)}
+      before do
+        posts = create_list(:post, 20)
+        visit posts_path
+      end
+      context '曲名検索の場合' do
+        it '曲名を入れて検索するとその曲が表示される' do
+          fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'aaaaa-music'
+          click_on I18n.t('defaults.search')
+          expect(page).to have_content('aaaaa-music')
+        end
+        it '曲名の一部を入れて検索するとその文字が含まれている全ての曲が表示される' do
+          fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'aaa'
+          click_on I18n.t('defaults.search')
+          expect(page).to have_content('aaaaa-music')
+          expect(page).to have_content('aaa-music')
+        end
+      end
+      context 'ユーザー検索の場合' do
+        it 'ユーザー名を入れて検索するとそのユーザーが表示される' do
+          fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'first-second'
+          click_on I18n.t('defaults.search')
+          expect(page).to have_content('first-second')
+        end
+        it 'ユーザー名の一部を入れて検索するとその文字が含まれている全てのユーザーが表示される' do
+          fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'ec'
+          click_on I18n.t('defaults.search')
+          expect(page).to have_content('sec-ir')
+          expect(page).to have_content('third-ec')
+          expect(page).to have_content('ec-music')
+        end
+      end
+    end
   end
 
   describe '新規投稿' do
@@ -47,7 +87,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('music-desu')
         click_on 'music-desu'
         expect(page).to have_selector 'iframe', wait: 5
@@ -56,7 +96,7 @@ RSpec.describe "Posts", js: true, type: :system do
       it '曲名と思い出が入力されていれば投稿できる' do
         fill_in Post.human_attribute_name(:music_name), with: 'music-desu'
         fill_in Post.human_attribute_name(:memory), with: 'memory-desu'
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('music-desu')
         expect(Post.count).to eq 1
       end
@@ -69,7 +109,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        expect{find('input[name="commit"]').click}.to change { Post.count }.by(0)
+        expect{click_on I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
       end
       it '思い出が空の時データの保存に失敗する' do
         fill_in Post.human_attribute_name(:music_name), with: 'music-desu'
@@ -77,14 +117,14 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        expect{find('input[name="commit"]').click}.to change { Post.count }.by(0)
+        expect{click_on I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
       end
       it '曲名と思い出が空の時もデータの保存に失敗する' do
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        expect{find('input[name="commit"]').click}.to change { Post.count }.by(0)
+        expect{click_on I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
       end
     end
   end
@@ -102,7 +142,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://www.youtube.com/watch?v=C-o8pTi6vd8&list=PLGAJbrONUQc_l3zZMKsbWqnd-af7psPqT&index=146'
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('musicnomemory')
         click_on 'musicnomemory'
         expect(page).to_not have_selector 'iframe', wait: 5
@@ -113,7 +153,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('musicnomemory')
         click_on 'musicnomemory'
         expect(page).to_not have_selector 'iframe', wait: 5
@@ -123,7 +163,7 @@ RSpec.describe "Posts", js: true, type: :system do
         fill_in Post.human_attribute_name(:memory), with: 'memory!'
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('musicnomemory')
         click_on 'musicnomemory'
         expect(page).to_not have_selector 'iframe', wait: 5
@@ -137,7 +177,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://www.youtube.com/watch?v=C-o8pTi6vd8&list=PLGAJbrONUQc_l3zZMKsbWqnd-af7psPqT&index=146'
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('狂乱Hey Kids!!')
         click_on '狂乱Hey Kids!!'
         expect(page).to have_selector 'iframe', wait: 5
@@ -149,7 +189,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='apple_music']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://music.apple.com/jp/album/%E3%81%95%E3%81%8F%E3%82%89%E3%82%93%E3%81%BC/76106703?i=76106271'
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('さくらんぼ')
         click_on 'さくらんぼ'
         expect(page).to have_selector 'iframe', wait: 5
@@ -161,7 +201,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='spotify']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://open.spotify.com/intl-ja/artist/0p4nmQO2msCgU4IF37Wi3j'
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.new.submit')
         expect(page).to have_content('girlfriend')
         click_on 'girlfriend'
         expect(page).to have_selector 'iframe', wait: 5
@@ -231,7 +271,7 @@ RSpec.describe "Posts", js: true, type: :system do
       expect(page).to have_selector 'iframe', wait: 5
     end
     context '正常系' do
-      it '全ての値を更新してリダイレクト先で情報が更新されている' do
+      it '全ての値を更新すると情報が更新されている' do
         visit edit_post_path(post1)
         fill_in Post.human_attribute_name(:music_name), with: 'music-desu'
         fill_in Post.human_attribute_name(:memory), with: 'memory-desu'
@@ -239,7 +279,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.edit.submit')
         expect(page).to have_content('music-desu')
         expect(page).to have_content('memory-desu')
         expect(page).to have_content('群馬県')
@@ -256,7 +296,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='']").select_option
         find("#post_embed_embed_type").find("option[value='']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: ""
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.edit.submit')
         expect(page).to have_content I18n.t('defaults.messages.post_update_failed')
       end
       it '曲名が空の時データの保存に失敗する' do
@@ -266,7 +306,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.edit.submit')
         expect(page).to have_content I18n.t('defaults.messages.post_update_failed')
       end
       it '思い出が空の時データの保存に失敗する' do
@@ -276,7 +316,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        find('input[name="commit"]').click
+        click_on I18n.t('posts.edit.submit')
         expect(page).to have_content I18n.t('defaults.messages.post_update_failed')
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users", type: :system do
         fill_in User.human_attribute_name(:email), with: Faker::Internet.unique.email
         fill_in User.human_attribute_name(:password), with: 'password'
         fill_in User.human_attribute_name(:password_confirmation), with: 'password'
-        expect{find('input[name="commit"]').click}.to change{ User.count }.by(1)
+        expect{click_on I18n.t('users.new.submit')}.to change{ User.count }.by(1)
       end
     end
     context '異常系' do
@@ -20,7 +20,7 @@ RSpec.describe "Users", type: :system do
       end
       let!(:user1) { create(:user) }
       it 'カラム未記入では新規登録できない' do
-        expect{find('input[name="commit"]').click}.to change{User.count}.by(0)
+        expect{click_on I18n.t('users.new.submit')}.to change{User.count}.by(0)
         expect(page).to have_content(I18n.t('users.new.title'))
         expect(page).to have_content(I18n.t('defaults.messages.signup_failed'))
       end
@@ -36,13 +36,13 @@ RSpec.describe "Users", type: :system do
       it 'ログイン成功' do
         fill_in User.human_attribute_name(:email), with: user.email
         fill_in User.human_attribute_name(:password), with: 'password'
-        find('input[name="commit"]').click
+        click_on I18n.t('user_sessions.new.submit')
         expect(page).to have_content(user.name)
       end
     end
     context '異常系' do
-      it '空欄のまま新規登録ボタンを押すとログインページへフラッシュメッセージと共に戻される' do
-        find('input[name="commit"]').click
+      it '空欄のままログインボタンを押すとログインページへフラッシュメッセージと共に戻される' do
+        click_on I18n.t('user_sessions.new.submit')
         expect(page).to have_content(I18n.t('defaults.messages.login_failed'))
       end
     end
@@ -107,7 +107,7 @@ RSpec.describe "Users", type: :system do
           find("#user_gender").find("option[value='male']").select_option
           find("#user_prefecture_id").find("option[value='14']").select_option
           fill_in User.human_attribute_name(:x_id), with: '@examplebbbbbbbbb1'
-          find('input[name="commit"]').click
+          click_on I18n.t('profiles.edit.update')
           expect(current_path).to eq profile_path
           expect(page).to have_content('user2')
           expect(page).to have_content('user2')
@@ -124,19 +124,19 @@ RSpec.describe "Users", type: :system do
       it '名前を空欄で更新すると失敗する' do
         fill_in User.human_attribute_name(:name), with: ''
         fill_in User.human_attribute_name(:email), with: 'user2@example.com'
-        find('input[name="commit"]').click
+        click_on I18n.t('profiles.edit.update')
         expect(page).to have_content I18n.t('defaults.messages.mypage_update_failed')
       end
       it 'メールアドレスを空欄で更新すると失敗する' do
         fill_in User.human_attribute_name(:name), with: 'user2'
         fill_in User.human_attribute_name(:email), with: ''
-        find('input[name="commit"]').click
+        click_on I18n.t('profiles.edit.update')
         expect(page).to have_content I18n.t('defaults.messages.mypage_update_failed')
       end
       it '名前とメールアドレスを空欄で更新すると失敗する' do
         fill_in User.human_attribute_name(:name), with: ''
         fill_in User.human_attribute_name(:email), with: ''
-        find('input[name="commit"]').click
+        click_on I18n.t('profiles.edit.update')
         expect(page).to have_content I18n.t('defaults.messages.mypage_update_failed')
       end
     end


### PR DESCRIPTION
Add: 検索機能とページネーション機能の基礎を実装しました

1.ransackとkaminariを用いて検索機能とページネーション機能の基礎を実装しました。
2.検索機能を全てのページから実行できるようにしたため、rspecの内容の送信ボタンをfind('input[name="commit"]').clickのような記述だとテストが通らなくなりました。そのため、一部のボタン名の翻訳ファイルの変更、テストデータでのボタンの記述の変更を行いました。

以下、テストの結果の一部です。
[![Image from Gyazo](https://i.gyazo.com/ced0be6d79ecc00e1478f168cd1c97d9.png)](https://gyazo.com/ced0be6d79ecc00e1478f168cd1c97d9)
[![Image from Gyazo](https://i.gyazo.com/caf1578a412326f82987c50ca0298022.png)](https://gyazo.com/caf1578a412326f82987c50ca0298022)