### PR TITLE
Add: 投稿に対するコメント作成、削除の機能を実装しました

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,26 @@
+class CommentsController < ApplicationController
+  def create
+    comment = current_user.comments.build(comment_params)
+    if comment.save
+      redirect_to post_path(comment.post), success: t('defaults.messages.comment_create_success')
+    else
+      redirect_to post_path(comment.post), danger: t('defaults.messages.comment_create_failed')
+    end
+  end
+
+  def update
+  end
+
+  def destroy
+    @comment = current_user.comments.find(params[:id])
+    @comment.destroy!
+    flash[:success] = t('defaults.messages.comment_destroy_success')
+    redirect_to post_path(@comment.post)
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(post_id: params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -28,7 +28,10 @@ class PostsController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @comment = Comment.new
+    @comments = @post.comments.includes(:user).order(created_at: :desc)
+  end
 
   def edit
     @post = current_user.posts.find(params[:id])

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  
+  validates :body, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   belongs_to :embed
+  has_many :comments, dependent: :destroy
   
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture

--- a/app/views/comments/_btn.html.erb
+++ b/app/views/comments/_btn.html.erb
@@ -1,0 +1,12 @@
+<ul class="list-unstyled list-inline float-right">
+  <li class="list-inline-item">
+    <%= link_to '#' do %>
+      <i class="fa-solid fa-pen"></i>
+    <% end %>
+  </li>
+  <li class="list-inline-item">
+    <%= link_to comment_path(comment), method: :delete, data: { confirm: t('comments.destroy.confirm') } do %>
+      <i class="fa-solid fa-trash-can"></i>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,16 @@
+<tr id="js-comment-<%= comment.id %>" class="position-relative">
+  <td style="width: 60px">
+    <%= image_tag comment.user.avatar_url, class: 'rounded-circle', size: '50x50' %>
+  </td>
+  <td>
+    <h3 class="small"><%= comment.user.name %></h3>
+    <div>
+      <%= simple_format(comment.body) %>
+    </div>
+    <% if logged_in? && current_user.mine?(comment) %>
+      <div class="position-absolute bottom-0 end-0">
+        <%= render 'comments/btn', comment: comment %>
+      </div>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,7 @@
+<table class="table">
+  <% if @comments.present? %>
+    <%= render @comments %>
+  <% else %>
+    <p><%= t('posts.show.no_comment') %></p>
+  <% end %>
+</table>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,9 @@
+<div class="row mb-3">
+  <div class="col-lg-8 offset-lg-2">
+    <%= form_with model: comment, url: [post, comment], id: 'new_comment' do |f| %>
+      <%= f.label :body, t('posts.show.comments_count', number: comments.count) %>
+      <%= f.text_field :body, class: 'form-control mb-3', id: 'js-comment-body', row: 4, placeholder: 'コメント' %>
+      <%= f.submit t('posts.show.comment_submit'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -46,3 +46,11 @@
   </table>
   <%= render 'crud_menu', post: @post %>
 </div>
+<div class="col-8 offset-2">
+  <%= render 'comments/form', { post: @post, comment: @comment, comments: @comments } %>
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2" id="js-comments">
+      <%= render 'comments/comments', { comments: @comments } %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,14 +3,14 @@
     <div class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
       <%= link_to posts_path, data: {"turbolinks" => false}, class:"d-flex align-items-center mb-3 mb-md-0 me-md-auto link-body-emphasis text-decoration-none" do %>
         <svg class="bi me-2" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
-        <h1 class="fs-2">Music Memory</h1>
+        <h1 class="fs-1">Music Memory</h1>
       <% end %>
 
       <%= search_form_for @q, url: posts_path, class: "col-lg-auto mt-1 mb-lg-0 me-lg-3 text-bottom" do |f| %>
         <%= f.search_field :music_name_or_memory_or_user_name_cont, placeholder: "Search..." %>
         <%= f.submit t('defaults.search') %>
       <% end %>
-            
+
       <ul class="nav nav-pills">
         <% if logged_in? %>
           <li class="nav-item"><%= link_to "About", '#', class: "nav-link" %></li>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -22,6 +22,8 @@ ja:
       embed:
         embed_type: "動画タイプ"
         identifer: "動画のURL"
+      comment:
+        body: "コメント"
   attributes:
     created_at: "作成日"
     updated_at: "更新日"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,6 +31,9 @@ ja:
       post_update_failed: "編集に失敗しました"
       mypage_update_success: "マイページを編集しました"
       mypage_update_failed: "編集に失敗しました"
+      comment_create_success: "コメントしました"
+      comment_create_failed: "コメントできませんでした"
+      comment_destroy_success: "コメントを削除しました"
   users:
     new:
       title: "新規登録"
@@ -53,9 +56,15 @@ ja:
       submit: "投稿"
     show:
       title: "投稿詳細"
+      comment_submit: "コメントする"
+      no_comment: "コメントはありません"
+      comments_count: "%{number}件のコメント"
     edit:
       title: "投稿編集"
       submit: "更新"
+  comments:
+    destroy:
+      confirm: "コメントを削除しますか？"
   profiles:
     show:
       title: "マイページ"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
   resources :users, only: %i[index new create show destroy]
-  resources :posts
+  resources :posts do
+    resources :comments, only: %i[create update destroy], shallow: true
+  end
   resource :profile, only: %i[show edit update]
 end

--- a/db/migrate/20231120234941_create_comments.rb
+++ b/db/migrate/20231120234941_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.string :body, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_18_034241) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_20_234941) do
+  create_table "comments", force: :cascade do |t|
+    t.string "body", null: false
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "embeds", force: :cascade do |t|
     t.integer "embed_type"
     t.string "identifer"
@@ -47,6 +57,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_18_034241) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "posts", "embeds"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    body { Faker::Lorem.sentence }
+    association :user
+    association :post
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:post) { create(:post, user_id: user2.id) }
+  context '' do
+
+  end
+  it 'コメント内容がある場合、有効' do
+    comment = Comment.new(
+      body: Faker::Lorem.sentence,
+      user_id: user1.id,
+      post_id: post.id
+    )
+    expect(comment).to be_valid
+  end
+  it 'コメント内容がない時、無効' do
+    comment = Comment.new(
+      body: "",
+      user_id: user1.id,
+      post_id: post.id
+    )
+    expect(comment).to be_invalid
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :rack_test
-    #driven_by :selenium_chrome_headless
+    #driven_by :rack_test
+    driven_by :selenium_chrome_headless
     #driven_by :selenium, using: :chrome, screen_size: [540, 540]
   end
   Capybara.default_driver = :rack_test

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :system do
+  describe 'コメント' do
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:post) { create(:post, user_id: user1.id) }
+    let!(:comment1) { create(:comment, post_id: post.id, user_id: user1.id)}
+    let!(:comment2) { create(:comment, post_id: post.id, user_id: user2.id)}
+    context '正常系' do
+      before do
+        login(user1)
+        visit post_path(post)
+      end
+      it 'ログインユーザーはコメント内容を入れるとコメントできる' do
+        fill_in 'comment[body]', with: "コメントです"
+        click_on I18n.t('posts.show.comment_submit')
+        expect(page).to have_content("コメントです")
+        expect(page).to have_content(I18n.t('defaults.messages.comment_create_success'))
+      end
+    end
+    context '異常系' do
+      it 'コメント内容が存在しないとコメントできない' do
+        login(user1)
+        visit post_path(post)
+        click_on I18n.t('posts.show.comment_submit')
+        expect(page).to have_content(I18n.t('defaults.messages.comment_create_failed'))
+      end
+      it 'ログインしていないとコメントできずログインページに戻される' do
+        visit post_path(post)
+        fill_in 'comment[body]', with: "コメントです"
+        click_on I18n.t('posts.show.comment_submit')
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
+  describe 'コメント' do
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:post) { create(:post, user_id: user1.id) }
+    let!(:comment1) { create(:comment, post_id: post.id, user_id: user1.id)}
+    let!(:comment2) { create(:comment, post_id: post.id, user_id: user2.id)}
+    context '正常系' do
+      before do
+        login(user1)
+        visit post_path(post)
+      end
+      it '自身のコメントを削除できる' do
+        comment_body = comment1.body
+        page.accept_confirm do
+          find("#js-comment-#{comment1.id} .fa-trash-can").click
+        end
+        expect(page).to_not have_content(comment_body)
+      end
+    end
+    context '異常系' do
+      it '他の人のコメントは削除できない' do
+        login(user1)
+        visit post_path(post)
+        expect(page).to_not have_selector "#js-comment-#{comment2.id} .fa-trash-can"
+      end
+      it 'ログインしていないとコメントの削除はできない' do
+        visit post_path(post)
+        expect(page).to_not have_selector "#js-comment-#{comment1.id} .fa-trash-can"
+        expect(page).to_not have_selector "#js-comment-#{comment2.id} .fa-trash-can"
+      end
+    end
+  end
+end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe "Posts", js: true, type: :system do
       context '曲名検索の場合' do
         it '曲名を入れて検索するとその曲が表示される' do
           fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'aaaaa-music'
-          click_on I18n.t('defaults.search')
+          click_button I18n.t('defaults.search')
           expect(page).to have_content('aaaaa-music')
         end
         it '曲名の一部を入れて検索するとその文字が含まれている全ての曲が表示される' do
           fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'aaa'
-          click_on I18n.t('defaults.search')
+          click_button I18n.t('defaults.search')
           expect(page).to have_content('aaaaa-music')
           expect(page).to have_content('aaa-music')
         end
@@ -59,12 +59,12 @@ RSpec.describe "Posts", js: true, type: :system do
       context 'ユーザー検索の場合' do
         it 'ユーザー名を入れて検索するとそのユーザーが表示される' do
           fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'first-second'
-          click_on I18n.t('defaults.search')
+          click_button I18n.t('defaults.search')
           expect(page).to have_content('first-second')
         end
         it 'ユーザー名の一部を入れて検索するとその文字が含まれている全てのユーザーが表示される' do
           fill_in "q[music_name_or_memory_or_user_name_cont]", with: 'ec'
-          click_on I18n.t('defaults.search')
+          click_button I18n.t('defaults.search')
           expect(page).to have_content('sec-ir')
           expect(page).to have_content('third-ec')
           expect(page).to have_content('ec-music')
@@ -87,16 +87,16 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('music-desu')
-        click_on 'music-desu'
+        click_link 'music-desu'
         expect(page).to have_selector 'iframe', wait: 5
         expect(Post.count).to eq 1
       end
       it '曲名と思い出が入力されていれば投稿できる' do
         fill_in Post.human_attribute_name(:music_name), with: 'music-desu'
         fill_in Post.human_attribute_name(:memory), with: 'memory-desu'
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('music-desu')
         expect(Post.count).to eq 1
       end
@@ -109,7 +109,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        expect{click_on I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
+        expect{click_button I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
       end
       it '思い出が空の時データの保存に失敗する' do
         fill_in Post.human_attribute_name(:music_name), with: 'music-desu'
@@ -117,14 +117,14 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        expect{click_on I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
+        expect{click_button I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
       end
       it '曲名と思い出が空の時もデータの保存に失敗する' do
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        expect{click_on I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
+        expect{click_button I18n.t('posts.new.submit')}.to change { Post.count }.by(0)
       end
     end
   end
@@ -142,9 +142,9 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://www.youtube.com/watch?v=C-o8pTi6vd8&list=PLGAJbrONUQc_l3zZMKsbWqnd-af7psPqT&index=146'
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('musicnomemory')
-        click_on 'musicnomemory'
+        click_link 'musicnomemory'
         expect(page).to_not have_selector 'iframe', wait: 5
       end
       it '動画URLのみ空欄で動画タイプが入力されている時iframeは表示されない' do
@@ -153,9 +153,9 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('musicnomemory')
-        click_on 'musicnomemory'
+        click_link 'musicnomemory'
         expect(page).to_not have_selector 'iframe', wait: 5
       end
       it '動画タイプと動画URLが両方空欄の時iframeは表示されない' do
@@ -163,9 +163,9 @@ RSpec.describe "Posts", js: true, type: :system do
         fill_in Post.human_attribute_name(:memory), with: 'memory!'
         find("#post_age_group").find("option[value='elementary']").select_option
         find("#post_prefecture_id").find("option[value='10']").select_option
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('musicnomemory')
-        click_on 'musicnomemory'
+        click_link 'musicnomemory'
         expect(page).to_not have_selector 'iframe', wait: 5
       end
     end
@@ -177,9 +177,9 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://www.youtube.com/watch?v=C-o8pTi6vd8&list=PLGAJbrONUQc_l3zZMKsbWqnd-af7psPqT&index=146'
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('狂乱Hey Kids!!')
-        click_on '狂乱Hey Kids!!'
+        click_link '狂乱Hey Kids!!'
         expect(page).to have_selector 'iframe', wait: 5
       end
       it 'iframeが表示される(apple_music)' do
@@ -189,9 +189,9 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='apple_music']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://music.apple.com/jp/album/%E3%81%95%E3%81%8F%E3%82%89%E3%82%93%E3%81%BC/76106703?i=76106271'
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('さくらんぼ')
-        click_on 'さくらんぼ'
+        click_link 'さくらんぼ'
         expect(page).to have_selector 'iframe', wait: 5
       end
       it 'iframeが表示される(spotify)' do
@@ -201,9 +201,9 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='spotify']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: 'https://open.spotify.com/intl-ja/artist/0p4nmQO2msCgU4IF37Wi3j'
-        click_on I18n.t('posts.new.submit')
+        click_button I18n.t('posts.new.submit')
         expect(page).to have_content('girlfriend')
-        click_on 'girlfriend'
+        click_link 'girlfriend'
         expect(page).to have_selector 'iframe', wait: 5
       end
     end
@@ -220,7 +220,7 @@ RSpec.describe "Posts", js: true, type: :system do
       let!(:post_show) { create(:post, user: user2, music_name: "あああ") }
       it '全ての項目が表示される' do
         visit posts_path
-        click_on post_show.music_name
+        click_link post_show.music_name
         expect(page).to have_content(post_show.music_name)
         expect(page).to have_content(post_show.memory)
         expect(page).to have_content(post_show.prefecture.name)
@@ -279,7 +279,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        click_on I18n.t('posts.edit.submit')
+        click_button I18n.t('posts.edit.submit')
         expect(page).to have_content('music-desu')
         expect(page).to have_content('memory-desu')
         expect(page).to have_content('群馬県')
@@ -296,7 +296,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='']").select_option
         find("#post_embed_embed_type").find("option[value='']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: ""
-        click_on I18n.t('posts.edit.submit')
+        click_button I18n.t('posts.edit.submit')
         expect(page).to have_content I18n.t('defaults.messages.post_update_failed')
       end
       it '曲名が空の時データの保存に失敗する' do
@@ -306,7 +306,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        click_on I18n.t('posts.edit.submit')
+        click_button I18n.t('posts.edit.submit')
         expect(page).to have_content I18n.t('defaults.messages.post_update_failed')
       end
       it '思い出が空の時データの保存に失敗する' do
@@ -316,7 +316,7 @@ RSpec.describe "Posts", js: true, type: :system do
         find("#post_prefecture_id").find("option[value='10']").select_option
         find("#post_embed_embed_type").find("option[value='youtube']").select_option
         fill_in Embed.human_attribute_name(:identifer), with: "lskfjlskdjflskdjlfkj"
-        click_on I18n.t('posts.edit.submit')
+        click_button I18n.t('posts.edit.submit')
         expect(page).to have_content I18n.t('defaults.messages.post_update_failed')
       end
     end


### PR DESCRIPTION
Add: 投稿に対するコメント作成、削除の機能を実装し、それに関連するテストを作成。

1.投稿に対してコメントの作成、削除を実装しました
2.コメント機能のシステムスペック、モデルスペック、Factorybotを利用したテストデータを作成しました。
3.今までcapybaraのrack_testでテストを行っていたのですが、削除の確認がどうしてもできなかったためselenium_chrome_headlessに変更しました。それに伴い、一部の記述を変更しました(click_onをclick_linkやclick_buttonへ)。

以下にテスト結果の一部を貼ります。
[![Image from Gyazo](https://i.gyazo.com/a3950c3b0f30dafd33311ac8b6bf5df2.png)](https://gyazo.com/a3950c3b0f30dafd33311ac8b6bf5df2)
[![Image from Gyazo](https://i.gyazo.com/edca84750eae39dd77d0d7ed17767314.png)](https://gyazo.com/edca84750eae39dd77d0d7ed17767314)