### PR TITLE
Add:follow機能をAjax化して実装しました

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,6 @@
+class RelationshipsController < ApplicationController
+  def create
+    @user = User.find_by(id: params[:user_id])
+    current_user.follow_sort(@user)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,22 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
   end
+
+  def show
+    @user = User.find(params[:id])
+    @following_users = @user.following_users
+    @follower_users = @user.follower_users
+  end
+  
+  def follows
+    @user = User.find(params[:id])
+    @users = @user.following_users
+  end
+  
+  def followers
+    @user = User.find(params[:id])
+    @users = @user.follower_users
+  end
   
   private
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,10 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
+  has_many :followers, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :followeds, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
+  has_many :following_users, through: :followers, source: :followed
+  has_many :follower_users, through: :followeds, source: :follower
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture
@@ -36,5 +40,17 @@ class User < ApplicationRecord
 
   def like?(post)
     like_posts.include?(post)
+  end
+
+  def follow_sort(user)
+    if self.following?(user)
+      followers.find_by(followed_id: user.id).destroy
+    else
+      followers.create(followed_id: user.id)
+    end
+  end
+  
+  def following?(user)
+    following_users.include?(user)
   end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -44,6 +44,11 @@
         <td><%= l @user.created_at, format: :ymd %></td>
       </tr>
     </table>
-    <%= link_to t('profiles.edit.title'), edit_profile_path %>
+    <div>
+      <%= link_to t('profiles.edit.title'), edit_profile_path %>
+    </div>
+    <div id="js-follow-button-<%= @user.id %>">
+      <%= render 'relationships/follow', user: @user %>
+    </div>
   </div>
 </div>

--- a/app/views/relationships/_follow.html.erb
+++ b/app/views/relationships/_follow.html.erb
@@ -1,0 +1,11 @@
+<% unless current_user.id == user.id %>
+  <% if current_user.following?(user) %>
+    <%= link_to t('users.show.unfollow'), user_relationships_path(user_id: user), method: :post, remote: true, class: 'btn btn-secondary' %>
+  <% else %>
+    <%= link_to t('users.show.follow'), user_relationships_path(user_id: user), method: :post, remote: true, class: 'btn btn-primary' %>
+  <% end %>
+<% end %>
+<div>
+  <%= "#{t('users.show.following_number')}: #{user.following_users.count}" %>
+  <%= "#{t('users.show.follower_number')}: #{user.follower_users.count}" %>
+</div>

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,1 @@
+$("#js-follow-button-<%= @user.id %>").html("<%= j(render('relationships/follow', user: @user)) %>")

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,12 @@
 <% content_for(:title, t('.title', user: @user.name)) %>
 <div class="container">
   <div class="row">
-    <h2 class="text-center"><%= t('.title', user: @user.name) %></h2>
-    <%= render "user", user: @user %>
+    <div class="text-center">
+      <h2><%= t('.title', user: @user.name) %></h2>
+      <%= render "user", user: @user %>
+      <div id="js-follow-button-<%= @user.id %>">
+        <%= render 'relationships/follow', user: @user %>
+      </div>
+    </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -41,6 +41,10 @@ ja:
       to_login_page: "ログインページはこちら"
     show:
       title: "%{user}さん"
+      follow: "フォローする"
+      unfollow: "フォローを外す"
+      following_number: "フォロー数"
+      follower_number: "フォロワー数"
   user_sessions:
     new:
       title: "ログイン"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,12 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
-  resources :users, only: %i[index new create show destroy]
+  resources :users, only: %i[index new create show] do
+    member do
+      get :follows, :followers
+    end
+    resource :relationships, only: %i[create]
+  end
   resources :posts do
     resources :comments, only: %i[create edit update destroy], shallow: true
     resource :like, only: %i[create]

--- a/db/migrate/20231121150632_create_relationships.rb
+++ b/db/migrate/20231121150632_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_21_132226) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_21_150632) do
   create_table "comments", force: :cascade do |t|
     t.string "body", null: false
     t.integer "user_id", null: false
@@ -49,6 +49,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_132226) do
     t.datetime "updated_at", null: false
     t.index ["embed_id"], name: "index_posts_on_embed_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :relationship do
+    #follower_id { 1 }
+    #followed_id { 1 }
+    association :follower
+    association :followed
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Like, type: :model do
-  it 'user_idとpost_idで一つのいいねを作成'
-  it '同じid同士で作成できない'
-  it 'user_idが入っていないと作成できない'
-  it 'post_idが入っていないと作成できない'
+  #it 'user_idとpost_idで一つのいいねを作成'
+  #it '同じid同士で作成できない'
+  #it 'user_idが入っていないと作成できない'
+  #it 'post_idが入っていないと作成できない'
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,8 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     #driven_by :rack_test
-    driven_by :selenium_chrome_headless
-    #driven_by :selenium, using: :chrome, screen_size: [540, 540]
+    #driven_by :selenium_chrome_headless
+    driven_by :selenium, using: :chrome, screen_size: [540, 540]
   end
   Capybara.default_driver = :rack_test
   Capybara.javascript_driver = :selenium_chrome_headless

--- a/spec/system/relationships_spec.rb
+++ b/spec/system/relationships_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.fdescribe "Relationships",js: true, type: :system do
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+  let!(:user3) { create(:user) }
+  let!(:follow1) { create(:relationship, follower_id: user3.id, followed_id: user2.id)}
+  let!(:follow2) { create(:relationship, follower_id: user2.id, followed_id: user3.id)}
+  describe '他のユーザーの詳細ページのフォロー状況' do
+    context 'ログインしている時' do
+      before do
+        login(user1)
+      end
+      context '相手をフォローしている時' do
+        let!(:myfollow) { create(:relationship, follower_id: user1.id, followed_id: user2.id)}
+        before { visit user_path(user2) }
+        it 'フォローを外すボタンが表示される' do
+          expect(page).to have_content(I18n.t('users.show.unfollow'))
+          expect(page).to have_selector("#js-follow-button-#{user2.id} a")
+        end
+        it 'フォロワー数がボタンを押すと1減る' do
+          expect(page).to have_content("フォロワー数: 2")
+          find("#js-follow-button-#{user2.id} a").click
+          expect(page).to have_content("フォロワー数: 1")
+        end
+      end
+      context '相手をフォローしていない時' do
+        before { visit user_path(user2) }
+        it 'フォローするボタンが表示される' do
+          expect(page).to have_content(I18n.t('users.show.follow'))
+          expect(page).to have_selector("#js-follow-button-#{user2.id} a")
+        end
+        it 'フォロワー数がボタンを押すと1減る' do
+          expect(page).to have_content("フォロワー数: 1")
+          find("#js-follow-button-#{user2.id} a").click
+          expect(page).to have_content("フォロワー数: 2")
+        end
+      end
+    end
+  end
+  fdescribe '自身のユーザー詳細ページのフォロー状況' do
+    before do
+      login(user1)
+      visit user_path(user1)
+    end
+    it 'フォロー数、フォロワー数が表示される' do
+      expect(page).to have_content("フォロー数:")
+      expect(page).to have_content("フォロワー数:")
+    end
+    it 'フォローボタン、フォロワーボタンは表示されない' do
+      expect(page).to_not have_content(I18n.t('users.show.follow'))
+      expect(page).to_not have_content(I18n.t('users.show.unfollow'))
+    end
+  end
+  describe '自身のマイページのフォロー状況' do
+    before do
+      login(user1)
+      visit profile_path
+    end
+    it 'フォロー数、フォロワー数が表示される' do
+      expect(page).to have_content("フォロー数:")
+      expect(page).to have_content("フォロワー数:")
+    end
+    it 'フォローボタン、フォロワーボタンは表示されない' do
+      expect(page).to_not have_content(I18n.t('users.show.follow'))
+      expect(page).to_not have_content(I18n.t('users.show.unfollow'))
+    end
+  end
+end


### PR DESCRIPTION
Add:follow機能をAjax化して実装しました。

1.follow機能をAjax化し、like機能と同様にcreateメソッドのみで機能するよう記述を少なくするように意識して実装しました。
2.follow機能のシステムスペックのテストを作成しました。
以下、テストの結果を添付します。
[![Image from Gyazo](https://i.gyazo.com/0b445111e63aad3a4bbde2ac29a31a18.png)](https://gyazo.com/0b445111e63aad3a4bbde2ac29a31a18)