### PR TITLE
Add: コメント、いいね、フォローに関して通知機能を実装しました

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,32 @@
+class NotificationsController < ApplicationController
+  def index
+    @notifications = current_user.received_notifications.includes(:notifiable, :sender).where(is_read: false).order(created_at: :desc)
+  end
+
+  def update
+    @notification = Notification.find(params[:id])
+    @notification.update_attribute(:is_read, true)
+  end
+
+  def all_update_read
+    @notifications = current_user.received_notifications.includes(:notifiable, :sender).where(is_read: false).order(created_at: :desc)
+    @notifications.each do |notification|
+      notification.update_attribute(:is_read, true)
+    end
+    redirect_to notifications_path, success: t('defaults.messages.all_already_read')
+  end
+
+  def already_read
+    @notifications = current_user.received_notifications.includes(:notifiable, :sender).where(is_read: true).order(created_at: :desc)
+  end
+
+  def delete_read
+    @notifications = current_user.received_notifications.where(is_read: true).order(created_at: :desc)
+    ActiveRecord::Base.transaction do
+      @notifications.each do |notification|
+        notification.destroy!
+      end
+    end
+    redirect_to already_read_notifications_path, success: t('defaults.messages.destroy_all_notifications')
+  end
+end

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,5 +1,22 @@
 class Chat < ApplicationRecord
   belongs_to :user
   belongs_to :room
+  has_one :notification, as: :notifiable, dependent: :destroy
+
   after_create_commit { ChatBroadcastJob.perform_later self }
+
+  def notification_message
+    user_room = UserRoom.where(room_id: self.room_id).where_not(user_id: self.user_id)
+    chat_partner = User.find(user_room.user_id)
+    chat_link = ActionController::Base.helpers.link_to("#{chat_partner.name} さん", Rails.application.routes.url_helpers.room_path(self.room_id))
+    "#{chat_link} があなたにメッセージを送りました".html_safe
+  end
+
+  private
+
+  def create_notifications
+    user_room = UserRoom.where(room_id: self.room_id).where_not(user_id: self.user_id)
+    notification = Notification.new(notifiable: self, sender: User.find(self.user_id), receiver: User.find(user_room.id))
+    notification.save(validate: false)
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,28 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  has_one :notification, as: :notifiable, dependent: :destroy
   
   validates :body, presence: true
+
+  after_create_commit :create_notifications
+
+  def notification_message
+    user = User.find(self.user_id)
+    post = Post.find(self.post_id)
+    user_link = ActionController::Base.helpers.link_to("#{user.name} さん", Rails.application.routes.url_helpers.user_path(user))
+    post_link = ActionController::Base.helpers.link_to(post.music_name, Rails.application.routes.url_helpers.post_path(post))
+    "#{user_link} が #{post_link} の投稿にコメントをしました".html_safe
+  end
+
+  private
+
+  def create_notifications
+    if self.user_id != self.post.user_id
+      notification = Notification.new(notifiable: self, sender: self.user, receiver: User.find(self.post.user_id))
+      notification.save(validate: false)
+    else
+      return false
+    end
+  end
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,6 +1,24 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  has_one :notification, as: :notifiable, dependent: :destroy
 
   validates :user_id, uniqueness: { scope: :post_id }
+
+  after_create_commit :create_notifications
+
+  def notification_message
+    user = User.find(user_id)
+    post = Post.find(post_id)
+    user_link = ActionController::Base.helpers.link_to("#{user.name} さん", Rails.application.routes.url_helpers.user_path(user))
+    post_link = ActionController::Base.helpers.link_to(post.music_name, Rails.application.routes.url_helpers.post_path(post))
+    "#{user_link} が #{post_link} の音楽の投稿にいいねをしました".html_safe
+  end
+
+  private
+
+  def create_notifications
+    notification = Notification.new(notifiable: self, sender: User.find(self.user_id), receiver: User.find(self.post.user_id))
+    notification.save(validate: false)
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,10 @@
+class Notification < ApplicationRecord
+  belongs_to :notifiable, polymorphic: true
+  belongs_to :like
+  belongs_to :comment
+  belongs_to :notifiable, polymorphic: true
+  belongs_to :sender, class_name: 'User', foreign_key: 'sender_id'
+  belongs_to :receiver, class_name: 'User', foreign_key: 'receiver_id'
+
+  scope :unread, -> { where(is_read: false) }
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,20 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
+  has_one :notification, as: :notifiable, dependent: :destroy
+
+  after_create_commit :create_notifications
+
+  def notification_message
+    follower = User.find(self.follower_id)
+    follower_link = ActionController::Base.helpers.link_to("#{follower.name} さん", Rails.application.routes.url_helpers.user_path(follower.id))
+    "#{follower_link} があなたをフォローをしました".html_safe
+  end
+
+  private
+
+  def create_notifications
+    notification = Notification.new(notifiable: self, sender: User.find(self.follower_id), receiver: User.find(self.followed_id))
+    notification.save(validate: false)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
   has_many :user_rooms
   has_many :chats
   has_many :rooms, through: :user_rooms
+  has_many :sent_notifications, class_name: 'Notification', foreign_key: 'sender_id', dependent: :destroy
+  has_many :received_notifications, class_name: 'Notification', foreign_key: 'receiver_id', dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,20 @@
+<div id="js-notification-<%= notification.id %>">
+  <div class="row border-top p-3 m-1 aaa">
+    <div class="col-1">
+      <% if !notification.is_read %>
+        <%= link_to notification_path(notification.id), method: :put, remote: true do %>
+          <i class="fa-solid fa-check" id="js-read-button-<%= notification.id %>"></i>
+        <% end %>
+      <% end %>
+    </div>
+    <div class="col-10 col-offset-1">
+      <%= image_tag(notification.sender.avatar_url, class: 'rounded-circle', size: '16x16') %>
+      <%= notification.notifiable.notification_message %>
+      <div class="text-muted pt-2">
+        <% if notification.notifiable_type == "Comment" %>
+          <%= notification.notifiable.body %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/notifications/already_read.html.erb
+++ b/app/views/notifications/already_read.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:title, t('.title')) %>
+<div class="row">
+  <h1 class="p-2 col-4 lh-base"><%= t('.title') %></h1>
+  <button class="col-3 offset-2 btn btn-light">
+    <%= link_to t('.new_notification_index'), notifications_path %>
+  </button>
+  <button class="col-3 btn btn-light">
+    <%= link_to t('.destroy_already_read'), delete_read_notifications_path, method: :delete %>
+  </button>
+</div>
+<div>
+  <% if @notifications.present? %>
+    <%= render @notifications %>
+  <% else %>
+    <p><%= t('defaults.messages.no_notification') %></p>
+  <% end %>
+</div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:title, t('.title')) %>
+<div class="row">
+  <h1 class="p-2 col-4 lh-base"><%= t('.title') %></h1>
+  <button class="col-3 offset-2 btn btn-light">
+    <%= link_to t('notifications.already_read.title'), already_read_notifications_path %>
+  </button>
+  <button class="col-3 btn btn-light">
+    <%= link_to t('.all_read'), all_update_read_notifications_path, method: :put %>
+  </button>
+</div>
+<div>
+  <% if @notifications.present? %>
+    <%= render @notifications %>
+  <% else %>
+    <p><%= t('defaults.messages.no_notification') %></p>
+  <% end %>
+</div>

--- a/app/views/notifications/update.js.erb
+++ b/app/views/notifications/update.js.erb
@@ -1,0 +1,1 @@
+$("#js-notification-<%= @notification.id %>").empty();

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,9 +13,8 @@
 
       <ul class="nav nav-pills">
         <% if logged_in? %>
-          <li class="nav-item"><%= link_to "About", '#', class: "nav-link" %></li>
           <li class="nav-item">
-            <%= link_to '#', class: "nav-link" do %>
+            <%= link_to notifications_path, class: "nav-link" do %>
               <i class="fa-solid fa-bell"></i>
             <% end %>
           </li>
@@ -23,7 +22,7 @@
           <li class="nav-item"><%= link_to t('defaults.new_post'), new_post_path, class: "nav-link" %></li>
           <li class="nav-item"><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "nav-link" %></li>
         <% else %>
-          <li class="nav-item"><%= link_to "Home", '#', class: "nav-link" %></li>
+          <li class="nav-item"><%= link_to t('defaults.home'), posts_path, class: "nav-link" %></li>
           <li class="nav-item"><%= link_to "About", '#', class: "nav-link" %></li>
           <li class="nav-item"><%= link_to t('defaults.login'), login_path, class: "nav-link" %></li>
           <li class="nav-item"><%= link_to t('defaults.signup'), signup_path, class: "nav-link" %></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     new_post: "新規投稿"
     mypage: "マイページ"
     search: "検索"
+    home: "投稿一覧"
     messages:
       not_authenticated: "ログインしてください"
       login_success: "ログインしました"
@@ -34,6 +35,9 @@ ja:
       comment_create_success: "コメントしました"
       comment_create_failed: "コメントできませんでした"
       comment_destroy_success: "コメントを削除しました"
+      all_already_read: "通知を全て既読にしました。"
+      destroy_all_notifications: "既読済みの通知を全て削除しました"
+      no_notification: "通知はありません"
   users:
     new:
       title: "新規登録"
@@ -91,3 +95,11 @@ ja:
       title: "チャットルーム"
       chat_submit: "送信"
       no_chat: "メッセージはありません"
+  notifications:
+    already_read:
+      title: "既読済み通知一覧"
+      new_notification_index: "新規通知一覧"
+      destroy_already_read: "既読済みの通知を削除する"
+    index:
+      title: "通知一覧"
+      all_read: "全て既読にする"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,4 +22,11 @@ Rails.application.routes.draw do
   resources :rooms, only: %i[index show create destroy] do
     resource :chat, only: %i[create]
   end
+  resources :notifications, only: %i[index update] do
+    collection do
+      put :all_update_read
+      get :already_read
+      delete :delete_read
+    end
+  end
 end

--- a/db/migrate/20231122081728_create_notifications.rb
+++ b/db/migrate/20231122081728_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notifications do |t|
+      t.references :notifiable, polymorphic: true, null: false
+      t.references :sender, User: true, null: false, foreign_key: { to_table: :users }
+      t.references :receiver, User: true, null: false, foreign_key: { to_table: :users }
+      t.boolean :is_read, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_22_003555) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_22_081728) do
   create_table "chats", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "room_id", null: false
@@ -46,6 +46,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_003555) do
     t.index ["post_id"], name: "index_likes_on_post_id"
     t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.string "notifiable_type", null: false
+    t.integer "notifiable_id", null: false
+    t.integer "sender_id", null: false
+    t.integer "receiver_id", null: false
+    t.boolean "is_read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["receiver_id"], name: "index_notifications_on_receiver_id"
+    t.index ["sender_id"], name: "index_notifications_on_sender_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -107,6 +120,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_003555) do
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "notifications", "users", column: "receiver_id"
+  add_foreign_key "notifications", "users", column: "sender_id"
   add_foreign_key "posts", "embeds"
   add_foreign_key "posts", "users"
   add_foreign_key "user_rooms", "rooms"

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :notification do
+    association :notifiable
+    association :like
+    association :comment
+    association :notifiable
+    association :sender
+    association :receiver
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Notifications", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,8 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     #driven_by :rack_test
-    driven_by :selenium_chrome_headless
-    #driven_by :selenium, using: :chrome, screen_size: [540, 540]
+    #driven_by :selenium_chrome_headless
+    driven_by :selenium, using: :chrome, screen_size: [540, 540]
   end
   Capybara.default_driver = :rack_test
   Capybara.javascript_driver = :selenium_chrome_headless

--- a/spec/system/chats_spec.rb
+++ b/spec/system/chats_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.fdescribe "Chats", type: :system do
+RSpec.describe "Chats", type: :system do
   let!(:user1) { create(:user) }
   let!(:user2) { create(:user) }
   describe 'チャットルームに関して' do

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.fdescribe "Notifications", js: true, type: :system do
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+  before { login(user1) }
+  context '通知がない時' do
+    it 'ベルマークを押すと通知一覧ページへ' do
+      find('a .fa-bell').click
+      expect(current_path).to eq notifications_path
+    end
+    it '通知がない時通知はないメッセージ' do
+      visit notifications_path
+      expect(page).to have_content(I18n.t('defaults.messages.no_notification'))
+    end
+  end
+  context '通知がある時' do
+    let!(:post) { create(:post, user_id: user1.id) }
+    let!(:comment1) { create(:comment, post_id: post.id, user_id: user1.id)}
+    let!(:comment2) { create(:comment, post_id: post.id, user_id: user2.id, body: "こめんと")}
+    let!(:like) { create(:like, post_id: post.id, user_id: user2.id)}
+    let!(:follow) { create(:relationship, follower_id: user2.id, followed_id: user1.id)}
+    before do
+      visit notifications_path
+    end
+    it 'チェックマークを押すと消える' do
+      find("#js-notification-#{comment2.notification.id} .fa-check").click
+      expect(page).to_not have_content(comment2.body)
+    end
+    it '全て既読にするを押すと消える' do
+      find_link(I18n.t('notifications.index.all_read')).click
+      expect(page).to have_content(I18n.t('defaults.messages.no_notification'))
+    end
+    it '全て既読にすると既読通知済み通知一覧へ移動' do
+      find_link(I18n.t('notifications.index.all_read')).click
+      expect(page).to_not have_content(comment2.body)
+      find_link(I18n.t('notifications.already_read.title')).click
+      expect(page).to have_content(comment2.body)
+    end
+    it '既読済み通知一覧で通知を全削除可能' do
+      find_link(I18n.t('notifications.index.all_read')).click
+      find_link(I18n.t('notifications.already_read.title')).click
+      find_link(I18n.t('notifications.already_read.destroy_already_read')).click
+      expect(page).to have_content(I18n.t('defaults.messages.no_notification'))
+    end
+  end
+  describe '通知が送られるか' do
+    let!(:post) { create(:post, user_id: user1.id) }
+    let!(:comment1) { create(:comment, post_id: post.id, user_id: user1.id, body: "あああああ")}
+    let!(:comment2) { create(:comment, post_id: post.id, user_id: user2.id, body: "こめんと")}
+    let!(:like) { create(:like, post_id: post.id, user_id: user2.id)}
+    let!(:follow) { create(:relationship, follower_id: user2.id, followed_id: user1.id)}
+    before do
+      visit notifications_path
+    end
+    it '自身の投稿へ自身が投稿しても通知されない' do
+      expect(page).to_not have_content(comment1.body)
+    end
+    it '自身の投稿へ他のユーザーからのコメントで通知が送られる' do
+      expect(page).to have_content(comment2.body)
+    end
+    it 'フォローした時に通知が送られる' do
+      expect(page).to have_content("あなたをフォローをしました")
+    end
+    it 'いいねした時に通知が送られる' do
+      expect(page).to have_content("音楽の投稿にいいねをしました")
+    end
+  end
+end


### PR DESCRIPTION
Add: コメント、いいね、フォローに関して通知機能を実装しました。
1.コメント、いいね、フォローに関して通知機能を実装しました。
2.通知一覧ページで通知を個別に既読、一括既読できるように実装しました。
3.既読済みの通知にしたものに関して一括削除ができるように実装しました。
4.コメントのみ自身の投稿へ自身がコメントしても通知には届かないように実装しました。
5.それぞれの通知に通知相手の名前がユーザー詳細ページへのリンクになるように実装しました。
6.それぞれの通知で異なる通知文で表示されるようにしました。
7.通知に関するテストを作成し、全てクリアしました。

以下、テスト結果を添付します。
[![Image from Gyazo](https://i.gyazo.com/54054aa86d5ad51ac661f21fe1b1469b.png)](https://gyazo.com/54054aa86d5ad51ac661f21fe1b1469b)
[備考]
chat機能に関して通知機能を実装しようとしていましたが、actioncableのメッセージ保存の過程でchatモデルでafter_create_commitを使用していて、そのためかもう一つafter_create_commitをすることができず通知がうまくいきませんでした。今後思いつき次第実装しようと思います。