### PR TITLE
Add: フォロー一覧とフォロワー一覧の追加と見た目の変更の試作を一部実施しました

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,17 @@
  *
  */
 @import "bootstrap";
+
+a {
+  text-decoration: none;
+  font-weight: 450;
+  font-size: 18px;
+  color: #198754;
+  &:hover {
+    opacity: .5;
+  }
+}
+
+table, h1, div {
+  color: #198754;
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,7 @@ class ProfilesController < ApplicationController
   def show
     @user = current_user
     @my_user_room = UserRoom.where(user_id: current_user.id)
+    @posts = current_user.like_posts.includes(:user).order(created_at: :desc).first(5)
   end
 
   def edit
@@ -10,13 +11,24 @@ class ProfilesController < ApplicationController
 
   def update
     @user = User.find(current_user.id)
-
     if @user.update(profile_params)
       redirect_to profile_path, success: t('defaults.messages.mypage_update_success')
     else
       flash.now[:danger] = t('defaults.messages.mypage_update_failed')
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def follows
+    @users = current_user.following_users
+  end
+  
+  def followers
+    @users = current_user.follower_users
+  end
+
+  def likes
+    @posts = current_user.like_posts.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,16 +46,6 @@ class UsersController < ApplicationController
     end
   end
   
-  def follows
-    @user = User.find(params[:id])
-    @users = @user.following_users
-  end
-  
-  def followers
-    @user = User.find(params[:id])
-    @users = @user.follower_users
-  end
-  
   private
 
   def user_params

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -5,6 +5,8 @@ class Relationship < ApplicationRecord
 
   after_create_commit :create_notifications
 
+  validates :follower_id, uniqueness: { scope: :followed_id }
+
   def notification_message
     follower = User.find(self.follower_id)
     follower_link = ActionController::Base.helpers.link_to("#{follower.name} さん", Rails.application.routes.url_helpers.user_path(follower.id))

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="bg-light">
     <%= render 'shared/header' %>
     <%= render 'shared/flash_message' %>
     <%= yield %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="card p-4">
       <table>
-        <tr><td><%= link_to post.music_name, post_path(post), class: "fs-2" %></td></tr>
+        <tr><td><%= link_to post.music_name, post_path(post), class: "fs-1" %></td></tr>
         <tr><td><%= post.memory %></td></tr>
         <tr><td><%= post.age_group_i18n %></td></tr>
         <% if post.prefecture.present? %>
@@ -10,7 +10,7 @@
         <% end %>
         <tr><td><%= link_to "#{t('defaults.contributor')}: #{post.user.name}", user_path(post.user) %></td></tr>
       </table>
-      <%= render 'crud_menu', post: post %>
+      <%= render 'posts/crud_menu', post: post %>
     </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,11 +10,9 @@
       <% elsif @post.embed.spotify? %>
         <%= content_tag 'iframe', nil, allow: "autoplay; encrypted-media *; fullscreen *; clipboard-write; picture-in-picture",loading: "lazy", frameborder: "0", height: "200px", style: "width:100%;max-width:660px;overflow:hidden;border-radius:10px;max-width:600px;", src: "https://open.spotify.com/embed/track/#{@post.embed.identifer}?utm_source=generator" %>
       <% end %>
-      <p><%= @post.embed.embed_type_i18n %></p>
-      <p><%= @post.embed.identifer %></p>
     <% end %>
   </div>
-  <table class="table table-light">
+  <table class="table table-striped">
     <tr>
       <th><%= t('defaults.contributor') %></th>
       <% if logged_in? && current_user.mine?(@post) %>

--- a/app/views/profiles/_follow_user.html.erb
+++ b/app/views/profiles/_follow_user.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <th scope="row"><%= link_to follow_user.name, user_path(follow_user.id) %></th>
+  <td><%= follow_user.x_id if follow_user.x_id.present? %></td>
+  <td><%= truncate(follow_user.profile) if follow_user.profile.present? %></td>
+</tr>

--- a/app/views/profiles/followers.html.erb
+++ b/app/views/profiles/followers.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="row">
+    <h1><%= t('.title') %></h1>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col"><%= User.human_attribute_name(:name) %></th>
+          <td scope="col"><%= User.human_attribute_name(:x_id) %></td>
+          <td scope="col"><%= User.human_attribute_name(:profile) %></td>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'follow_user', collection: @users %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/profiles/follows.html.erb
+++ b/app/views/profiles/follows.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="row">
+    <h1><%= t('.title') %></h1>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col"><%= User.human_attribute_name(:name) %></th>
+          <td scope="col"><%= User.human_attribute_name(:x_id) %></td>
+          <td scope="col"><%= User.human_attribute_name(:profile) %></td>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'follow_user', collection: @users %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/profiles/likes.html.erb
+++ b/app/views/profiles/likes.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="row">
+    <div class="col-10 offset-1">
+      <h1 class="mt-4 mb-4"><%= t('.title') %></h1>
+      <% if @posts.present? %>
+        <%= render partial: 'posts/post', collection: @posts %>
+      <% else %>
+        <div><%= t('defaults.messages.no_posts') %></div>
+      <% end %>
+    </div>
+    <%= paginate @posts, theme: 'bootstrap-5' %>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,60 +1,78 @@
 <% content_for(:title, t('.title')) %>
-<div class="m-3 p-4">
-  <h2><%= t('.title') %></h2>
-  <div class="card p-3 col-8 offset-2">
-    <div>
-      <%= image_tag @user.avatar_url, size: '200x200', class: 'rounded-circle mr15 d-block mb-5 mx-auto' %>
-    </div>  
-    <table>
-      <tr>
-        <td><%= User.human_attribute_name(:name) %></td>
-        <td><%= @user.name %></td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:email) %></td>
-        <td><%= @user.email %></td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:profile) %></td>
-        <td><%= @user.profile if !@user.profile.nil? %></td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:birthday) %></td>
-        <td><%= @user.birthday.strftime("%Y/%m") if !@user.birthday.nil? %></td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:prefecture_id) %></td>
-        <td><%= @user.prefecture.name if !@user.prefecture.nil? %></td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:x_id) %></td>
-        <td>
-          <% if !@user.x_id.blank? %>
-            <i class="fa-brands fa-x-twitter"></i>
-            <%= link_to @user.x_id, "https://mobile.twitter.com/#{@user.x_id}", target: :_blank, rel: "noopener noreferrer" %>
-          <% end %>
-        </td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:gender) %></td>
-        <td><%= @user.gender_i18n if !@user.gender.nil? %></td>
-      </tr>
-      <tr>
-        <td><%= User.human_attribute_name(:created_at) %></td>
-        <td><%= l @user.created_at, format: :ymd %></td>
-      </tr>
-    </table>
-    <div>
-      <%= link_to t('profiles.edit.title'), edit_profile_path %>
+<div class="container">
+  <div class="row">
+    <h2 class="pt-3 pb-3"><%= t('.title') %></h2>
+    <div class="card p-3 col-6">
+      <div>
+        <%= image_tag @user.avatar_url, size: '200x200', class: 'rounded-circle mr15 d-block mb-5 mx-auto' %>
+      </div>  
+      <table>
+        <tr>
+          <td><%= User.human_attribute_name(:name) %></td>
+          <td><%= @user.name %></td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:email) %></td>
+          <td><%= @user.email %></td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:profile) %></td>
+          <td><%= @user.profile if !@user.profile.nil? %></td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:birthday) %></td>
+          <td><%= @user.birthday.strftime("%Y/%m") if !@user.birthday.nil? %></td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:prefecture_id) %></td>
+          <td><%= @user.prefecture.name if !@user.prefecture.nil? %></td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:x_id) %></td>
+          <td>
+            <% if !@user.x_id.blank? %>
+              <i class="fa-brands fa-x-twitter"></i>
+              <%= link_to @user.x_id, "https://mobile.twitter.com/#{@user.x_id}", target: :_blank, rel: "noopener noreferrer" %>
+            <% end %>
+          </td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:gender) %></td>
+          <td><%= @user.gender_i18n if !@user.gender.nil? %></td>
+        </tr>
+        <tr>
+          <td><%= User.human_attribute_name(:created_at) %></td>
+          <td><%= l @user.created_at, format: :ymd %></td>
+        </tr>
+      </table>
+      <div>
+        <%= link_to t('profiles.edit.title'), edit_profile_path %>
+      </div>
+      <div id="js-follow-button-<%= @user.id %>">
+        <%= render 'relationships/follow', user: @user %>
+      </div>
+      <div>
+        <% if @my_user_room.present? %>
+          <%= link_to t('.room_index'), rooms_path %>
+        <% else %>
+          <p><%= t('.no_room') %></p>
+        <% end %>
+      </div>
     </div>
-    <div id="js-follow-button-<%= @user.id %>">
-      <%= render 'relationships/follow', user: @user %>
-    </div>
-    <div>
-      <% if @my_user_room.present? %>
-        <%= link_to t('.room_index'), rooms_path %>
-      <% else %>
-        <p><%= t('.no_room') %></p>
+    <div class="col-6 card">
+      <%= link_to t('.like_posts'), likes_profile_path %>
+      <% @posts.each do |post| %>
+        <div class="card">
+          <table>
+            <tr><td><%= link_to post.music_name, post_path(post), class: "fs-1" %></td></tr>
+            <tr><td><%= post.memory %></td></tr>
+            <tr><td><%= post.age_group_i18n if post.age_group.present? %></td></tr>
+            <% if post.prefecture.present? %>
+              <tr><td><%= post.prefecture.name %></td></tr>
+            <% end %>
+            <tr><td><%= link_to "#{t('defaults.contributor')}: #{post.user.name}", user_path(post.user) %></td></tr>
+          </table>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/relationships/_follow.html.erb
+++ b/app/views/relationships/_follow.html.erb
@@ -1,11 +1,16 @@
 <% unless current_user.id == user.id %>
   <% if current_user.following?(user) %>
-    <%= link_to t('users.show.unfollow'), user_relationships_path(user_id: user), method: :post, remote: true, class: 'btn btn-secondary' %>
+    <%= link_to t('relationships.unfollow'), user_relationships_path(user_id: user), method: :post, remote: true, class: 'btn btn-secondary' %>
   <% else %>
-    <%= link_to t('users.show.follow'), user_relationships_path(user_id: user), method: :post, remote: true, class: 'btn btn-primary' %>
+    <%= link_to t('relationships.follow'), user_relationships_path(user_id: user), method: :post, remote: true, class: 'btn btn-primary' %>
   <% end %>
 <% end %>
 <div>
-  <%= "#{t('users.show.following_number')}: #{user.following_users.count}" %>
-  <%= "#{t('users.show.follower_number')}: #{user.follower_users.count}" %>
+  <% if current_page?(profile_path) || user.id == current_user.id %>
+    <p><%= link_to t('defaults.following_number'), follows_profile_path %>: <%= user.following_users.count %></p>
+    <p><%= link_to t('defaults.follower_number'), followers_profile_path %>: <%= user.follower_users.count %></p>
+  <% else %>
+    <%= t('defaults.following_number') %>: <%= user.following_users.count %>
+    <%= t('defaults.follower_number') %>: <%= user.follower_users.count %>
+  <% end %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,9 @@
-<header class="p-3 mb-3 border-bottom">
+<header class="p-3 mb-3 border-bottom bg-success p-2 bg-opacity-10">
   <div class="container">
     <div class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
       <%= link_to posts_path, data: {"turbolinks" => false}, class:"d-flex align-items-center mb-3 mb-md-0 me-md-auto link-body-emphasis text-decoration-none" do %>
         <svg class="bi me-2" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
-        <h1 class="fs-1">Music Memory</h1>
+        <h1 class="fs-1 text-success">Music Memory</h1>
       <% end %>
 
       <%= search_form_for @q, url: posts_path, class: "col-lg-auto mt-1 mb-lg-0 me-lg-3 text-bottom" do |f| %>
@@ -15,17 +15,17 @@
         <% if logged_in? %>
           <li class="nav-item">
             <%= link_to notifications_path, class: "nav-link" do %>
-              <i class="fa-solid fa-bell"></i>
+              <i class="fa-solid fa-bell text-success"></i>
             <% end %>
           </li>
-          <li class="nav-item"><%= link_to t('defaults.mypage'), profile_path, class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to t('defaults.new_post'), new_post_path, class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "nav-link" %></li>
+          <li class="nav-item"><%= link_to t('defaults.mypage'), profile_path, class: "nav-link text-success" %></li>
+          <li class="nav-item"><%= link_to t('defaults.new_post'), new_post_path, class: "nav-link text-success" %></li>
+          <li class="nav-item"><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "nav-link text-success" %></li>
         <% else %>
-          <li class="nav-item"><%= link_to t('defaults.home'), posts_path, class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to "About", '#', class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to t('defaults.login'), login_path, class: "nav-link" %></li>
-          <li class="nav-item"><%= link_to t('defaults.signup'), signup_path, class: "nav-link" %></li>
+          <li class="nav-item"><%= link_to t('defaults.home'), posts_path, class: "nav-link text-success" %></li>
+          <li class="nav-item"><%= link_to "About", '#', class: "nav-link text-success" %></li>
+          <li class="nav-item"><%= link_to t('defaults.login'), login_path, class: "nav-link text-success" %></li>
+          <li class="nav-item"><%= link_to t('defaults.signup'), signup_path, class: "nav-link text-success" %></li>
         <% end %>
       </ul>
       <div class="text-right">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -9,6 +9,8 @@ ja:
     mypage: "マイページ"
     search: "検索"
     home: "投稿一覧"
+    following_number: "フォロー"
+    follower_number: "フォロワー"
     messages:
       not_authenticated: "ログインしてください"
       login_success: "ログインしました"
@@ -47,8 +49,8 @@ ja:
       title: "%{user}さん"
       follow: "フォローする"
       unfollow: "フォローを外す"
-      following_number: "フォロー数"
-      follower_number: "フォロワー数"
+      following_number: "フォロー"
+      follower_number: "フォロワー"
       no_room: "チャットルームはありません"
       chat: "チャットをする"
       start_chat: "チャットを開始する"
@@ -85,9 +87,16 @@ ja:
       title: "マイページ"
       room_index: "チャットルーム一覧"
       no_room: "チャットルームはありません"
+      like_posts: ">いいねした投稿"
     edit:
       title: "マイページ編集"
       update: "更新"
+    follows:
+      title: "フォロー一覧"
+    followers:
+      title: "フォロワー一覧"
+    likes:
+      title: "いいねした投稿"
   rooms:
     index:
       title: "チャットルーム一覧"
@@ -103,3 +112,6 @@ ja:
     index:
       title: "通知一覧"
       all_read: "全て既読にする"
+  relationships:
+    follow: "フォローする"
+    unfollow: "フォローを外す"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,19 +6,17 @@ Rails.application.routes.draw do
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
   resources :users, only: %i[index new create show] do
-    member do
-      get :follows, :followers
-    end
     resource :relationships, only: %i[create]
   end
   resources :posts do
     resources :comments, only: %i[create edit update destroy], shallow: true
     resource :like, only: %i[create]
+  end
+  resource :profile, only: %i[show edit update] do
     collection do
-      get :likes
+      get :follows, :followers, :likes
     end
   end
-  resource :profile, only: %i[show edit update]
   resources :rooms, only: %i[index show create destroy] do
     resource :chat, only: %i[create]
   end

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :relationship do
-    #follower_id { 1 }
-    #followed_id { 1 }
+    follower_id { rand(1...10) }
+    followed_id { rand(1...10) }
     association :follower
     association :followed
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,7 +2,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     #driven_by :rack_test
     #driven_by :selenium_chrome_headless
-    driven_by :selenium, using: :chrome, screen_size: [540, 540]
+    driven_by :selenium, using: :chrome, screen_size: [540, 800]
   end
   Capybara.default_driver = :rack_test
   Capybara.javascript_driver = :selenium_chrome_headless

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.fdescribe "Notifications", js: true, type: :system do
+RSpec.describe "Notifications", js: true, type: :system do
   let!(:user1) { create(:user) }
   let!(:user2) { create(:user) }
   before { login(user1) }

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.fdescribe "Profiles", type: :system do
+  describe 'プロフィール詳細' do
+    let!(:user1) { create(:user, x_id: '@exampleaaaaaaaaaa1') }
+    context '正常系' do
+      it '初期の新規登録後には最低限のもののみ表示される' do
+        login(user1)
+        visit profile_path
+        expect(page).to have_content user1.name
+        expect(page).to have_content user1.email
+        expect(page).to have_content user1.gender_i18n
+      end
+    end
+    context '異常系' do
+      it 'ログインしていないとプロフィール詳細には移動できない' do
+        visit profile_path
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
+  describe 'プロフィール編集' do
+    let!(:user1) { create(:user, x_id: '@exampleaaaaaaaaaa1') }
+    before do
+      login(user1)
+      visit profile_path
+      click_link I18n.t('profiles.edit.title')
+    end
+    context '正常系' do
+      describe 'プロフィール編集後のプロフィール画面' do
+        it '編集画面で記入して更新するとプロフィール画面で表示される' do
+          fill_in User.human_attribute_name(:name), with: 'user2'
+          fill_in User.human_attribute_name(:email), with: 'user2@example.com'
+          fill_in User.human_attribute_name(:profile), with: '好きな音楽は色々。吹奏楽の曲も好きです。'
+          find("#user_birthday_1i").find("option[value='1999']").select_option
+          find("#user_birthday_2i").find("option[value='9']").select_option
+          find("#user_gender").find("option[value='male']").select_option
+          find("#user_prefecture_id").find("option[value='14']").select_option
+          fill_in User.human_attribute_name(:x_id), with: '@examplebbbbbbbbb1'
+          click_button I18n.t('profiles.edit.update')
+          expect(current_path).to eq profile_path
+          expect(page).to have_content('user2')
+          expect(page).to have_content('user2')
+          expect(page).to have_content('好きな音楽は色々。吹奏楽の曲も好きです。')
+          expect(page).to have_content('1999/09')
+          expect(page).to have_content('神奈川')
+          expect(page).to have_content('男性')
+          expect(page).to have_link "@examplebbbbbbbbb1", href: "https://mobile.twitter.com/@examplebbbbbbbbb1"
+        end
+      end
+    end
+
+    context '異常系' do
+      it '名前を空欄で更新すると失敗する' do
+        fill_in User.human_attribute_name(:name), with: ''
+        fill_in User.human_attribute_name(:email), with: 'user2@example.com'
+        click_button I18n.t('profiles.edit.update')
+        expect(page).to have_content I18n.t('defaults.messages.mypage_update_failed')
+      end
+      it 'メールアドレスを空欄で更新すると失敗する' do
+        fill_in User.human_attribute_name(:name), with: 'user2'
+        fill_in User.human_attribute_name(:email), with: ''
+        click_button I18n.t('profiles.edit.update')
+        expect(page).to have_content I18n.t('defaults.messages.mypage_update_failed')
+      end
+      it '名前とメールアドレスを空欄で更新すると失敗する' do
+        fill_in User.human_attribute_name(:name), with: ''
+        fill_in User.human_attribute_name(:email), with: ''
+        click_button I18n.t('profiles.edit.update')
+        expect(page).to have_content I18n.t('defaults.messages.mypage_update_failed')
+      end
+    end
+  end
+
+  describe 'プロフィールのネスト' do
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:user3) { create(:user) }
+    let!(:post1) { create(:post, user_id: user1.id) }
+    let!(:post2) { create(:post, user_id: user2.id) }
+    let!(:post3) { create(:post, user_id: user3.id) }
+    let!(:follow1) { create(:relationship, follower_id: user2.id, followed_id: user1.id) }
+    let!(:follow2) { create(:relationship, follower_id: user3.id, followed_id: user1.id) }
+    let!(:follow3) { create(:relationship, follower_id: user1.id, followed_id: user2.id) }
+    let!(:like1) { create(:like, user_id: 1) }
+    before do
+      likes = create_list(:like, 5, user_id: user1.id)
+      login(user1)
+      visit profile_path
+    end
+    describe 'フォロー一覧' do
+      it 'プロフィールでフォロー数が表示される' do
+        following_users_number = user1.following_users.count
+        expect("#js-follow-button-#{user1.id}").to have_content(following_users_number)
+      end
+      it 'フォローを押すとフォロー一覧へ移動' do
+        click_on I18n.t('defaults.following_number')
+        expect(current_path).to eq follows_profile_path
+      end
+    end
+
+    describe 'フォロワー一覧' do
+      it 'フォロワーを押すとフォロワー一覧へ移動' do
+        click_on "フォロワー"
+        expect(current_path).to eq followers_profile_path
+      end
+    end
+
+    describe 'いいねした投稿一覧' do
+      it 'プロフィールでいいねした投稿一覧の一部が表示' do
+        expect(page).to have_content(user1.like_posts.last.memory)
+      end
+      it 'プロフィールからいいねした投稿一覧へ移動できる' do
+        expect(page).to have_link(I18n.t('profiles.show.like_posts'))
+        click_link I18n.t('profiles.show.like_posts')
+        expect(page).to have_content(user1.like_posts.first.memory)
+      end
+    end
+  end
+end

--- a/spec/system/relationships_spec.rb
+++ b/spec/system/relationships_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe "Relationships",js: true, type: :system do
           expect(page).to have_selector("#js-follow-button-#{user2.id} a")
         end
         it 'フォロワー数がボタンを押すと1減る' do
-          expect(page).to have_content("フォロワー数: 2")
-          find("#js-follow-button-#{user2.id} a").click
-          expect(page).to have_content("フォロワー数: 1")
+          expect(user2.follower_users.count).to eq (2)
+          find("#js-follow-button-#{user2.id} .btn-secondary").click
+          visit user_path(user2)
+          expect(user2.follower_users.count).to eq (1)
         end
       end
       context '相手をフォローしていない時' do
@@ -31,9 +32,10 @@ RSpec.describe "Relationships",js: true, type: :system do
           expect(page).to have_selector("#js-follow-button-#{user2.id} a")
         end
         it 'フォロワー数がボタンを押すと1減る' do
-          expect(page).to have_content("フォロワー数: 1")
-          find("#js-follow-button-#{user2.id} a").click
-          expect(page).to have_content("フォロワー数: 2")
+          expect(user2.follower_users.count).to eq (1)
+          find("#js-follow-button-#{user2.id} .btn-primary").click
+          visit user_path(user2)
+          expect(user2.follower_users.count).to eq (2)
         end
       end
     end
@@ -44,8 +46,8 @@ RSpec.describe "Relationships",js: true, type: :system do
       visit user_path(user1)
     end
     it 'フォロー数、フォロワー数が表示される' do
-      expect(page).to have_content("フォロー数:")
-      expect(page).to have_content("フォロワー数:")
+      expect(page).to have_content(user1.follower_users.count)
+      expect(page).to have_content(user1.following_users.count)
     end
     it 'フォローボタン、フォロワーボタンは表示されない' do
       expect(page).to_not have_content(I18n.t('users.show.follow'))
@@ -58,9 +60,8 @@ RSpec.describe "Relationships",js: true, type: :system do
       visit profile_path
     end
     it 'フォロー数、フォロワー数が表示される' do
-      binding.pry
-      expect(page).to have_content("フォロー数:")
-      expect(page).to have_content("フォロワー数:")
+      expect(page).to have_link("フォロー")
+      expect(page).to have_link("フォロワー")
     end
     it 'フォローボタン、フォロワーボタンは表示されない' do
       expect(page).to_not have_content(I18n.t('users.show.follow'))


### PR DESCRIPTION
branch名: feature/add_follow_index
Add: フォロー一覧とフォロワー一覧の追加と見た目の変更の試作を一部実施しました。

1.フォローしたユーザーの一覧とフォロワーの一覧をプロフィールページに実装しました。
2.アプリの見た目について少し変更を加えました。試作なので今後変更する可能性が高いです。
3.いいねした投稿一覧をprofileページに5件まで表示し、さらにそれらを全て表示できるページを用意しました。
4.フォロー一覧とフォロワー一覧、いいねした投稿一覧のルーティングをプロフィールに基づくものとしました。
5.フォローのテストに関して、これまでの変更でテストがクリアできなくなっていたので編集しました。
6.ユーザーのシステムスペックに記述したプロフィール関連のものをプロフィールのシステムスペックを作成してそこに移動しました。
7.フォロー一覧、フォロワー一覧、いいね一覧に関するテストを追加しました。

以下、今回のテストの結果を添付します。
[![Image from Gyazo](https://i.gyazo.com/5fbc1d4fc58564fec9d10a0c29cba743.png)](https://gyazo.com/5fbc1d4fc58564fec9d10a0c29cba743)