### PR TITLE
Fix:ヘッダーのレイアウトを変更しました。formのplaceholderの色も変更しました。

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,10 @@ h1, div, p, small, .title-color, .orange-color {
   color: #ea5504;
 }
 
+.orange-color {
+  color: #ea5504;
+}
+
 table tr {
   color: #ea5504;
 }
@@ -106,4 +110,25 @@ table tr {
 footer {
   height: 120px;
   background-color: #ea5504;
+}
+
+input{
+  border-color: white;
+  border-radius: 8px;
+  &::placeholder {
+  color: #ea5504;
+  opacity: .6;
+  }
+}
+
+label{
+  color: #ea5504;
+  font-size: 20px;
+}
+
+input.form-control, textarea.form-control {
+  &::placeholder {
+    color: #ea5504;
+    opacity: .6;
+  }
 }

--- a/app/views/posts/_crud_menu.html.erb
+++ b/app/views/posts/_crud_menu.html.erb
@@ -2,7 +2,7 @@
   <li class="list-inline-item" id="search-post-<%= post.id %>">
     <% unless current_page?(post_path(post)) %>
       <%= link_to post_path(post), id: "show-post-#{post.id}" do %>
-        <i class="fas fa-search"></i> 
+        <i class="fa-solid fa-circle-info"></i>
       <% end %>
     <% end %>
   </li>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -27,5 +27,5 @@
     </div>
   </div>
 </div>
-
+<script src="javascript/channels/room_channel.js"></script>
 <%= javascript_import_module_tag "channels" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,20 +21,25 @@
               <i class="fa-solid fa-bell"></i>
             <% end %>
           </li>
-          <li class="nav-item"><%= link_to t('defaults.mypage'), profile_path, class: "nav-link text-white" %></li>
           <li class="nav-item"><%= link_to t('defaults.new_post'), new_post_path, class: "nav-link text-white" %></li>
-          <li class="nav-item"><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "nav-link text-white" %></li>
+          
+          <li class="nav-item">
+            <div class="dropdown">
+              <button class="btn btn-orange dropdown-toggle border border-white border-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="fa-regular fa-user fs-5"></i>
+              </button>
+              <ul class="dropdown-menu bg-white">
+                <li><%= link_to t('defaults.mypage'), profile_path, class: "dropdown-item orange-color" %></li>
+                <li><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "dropdown-item orange-color" %></li>
+              </ul>
+            </div>
+          </li>
         <% else %>
           <li class="nav-item"><%= link_to t('defaults.home'), posts_path, class: "nav-link text-white" %></li>
           <li class="nav-item"><%= link_to t('defaults.login'), login_path, class: "nav-link text-white" %></li>
           <li class="nav-item"><%= link_to t('defaults.signup'), signup_path, class: "nav-link text-white" %></li>
         <% end %>
       </ul>
-      <li class="nav-item pt-1">
-        <% if logged_in? %>
-          <p class="text-white nav-link">[ID:<%= current_user.id %>]<%= current_user.name %></p>
-        <% end %>
-      </li>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Fix: ヘッダーのレイアウト、formのplaceholderの色、投稿一覧にある投稿の詳細への導線のアイコンを変更しました
1.views/rooms/show.html.erbに明示的にjavascript/channels/room_channel.jsを読み込むことでチャット機能が機能するか試してみました。
2.ログイン後のマイページとログアウトをまとめてドロップダウンにまとめました。
3.placeholderの色を薄くしました。
4.form_withのセレクトの色を変更することはできるのですが、選んだ後の色を変更できなかったのでそのままの色にしてあります。
5.ログイン後にIDと名前がヘッダーに中に表示されないように変更しました。
6.投稿一覧にある投稿の詳細ページへの導線に使用するアイコンを変更しました。