### PR TITLE
Fix:developmentとproductionのactionmailerに関しての記述部分を反対に書いてしまっていたので変更

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
 
-  config.action_mailer.default_url_options = { protocol: 'https', host:'https://music-memory-app-ab0d434751b2.herokuapp.com/' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { protocol: 'https', host:'https://music-memory-app-ab0d434751b2.herokuapp.com/' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Fix:developmentとproductionのactionmailerに関しての記述部分を反対に書いてしまっていたので変更
動作確認の段階では反対に書いてはいましたが、開発環境では正常に動いていました。