### PR TITLE
add: オートコンプリート機能を投稿検索に追加しました。また、検索に反映するカラムを一部変更し、それに伴い、modelなどへの記述も変更しました。

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -60,6 +60,13 @@ class PostsController < ApplicationController
     redirect_to posts_path, success: t('defaults.messages.delete_post')
   end
 
+  def search
+    @posts = Post.where("music_name like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def post_params

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,3 +8,8 @@ import { Turbo } from "@hotwired/turbo-rails"
 Turbo.session.drive = false
 import "controllers"
 import "@fortawesome/fontawesome-free"
+import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
+
+const application = Application.start()
+application.register('autocomplete', Autocomplete)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,10 +32,10 @@ class Post < ApplicationRecord
                   }
   
   def self.ransackable_attributes(auth_object = nil)
-    ["age_group", "created_at", "embed_id", "memory", "music_name", "prefecture_id", "user_id"]
+    ["music_name"]
   end
   
   def self.ransackable_associations(auth_object = nil)
-    ["comments", "embed", "like_users", "likes", "prefecture", "user"]
+    ["user"]
   end
 end

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,0 +1,5 @@
+<% @posts.each do |post| %>
+  <li class="bg-white w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= post.id %>" data-autocomplete-label="<%= post.music_name %>">
+    <%= post.music_name %>
+  </li>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,8 +9,12 @@
       
       <div class="nav-link">
         <%= search_form_for @q, url: posts_path, class: "col-lg-auto mt-1 mb-lg-0 me-lg-3 text-bottom" do |f| %>
-          <%= f.search_field :music_name_or_memory_or_user_name_cont, placeholder: "Search..." %>
-          <%= f.submit t('defaults.search'), class: "btn-search" %>
+          <div data-controller="autocomplete" data-autocomplete-url-value="/posts/search" role="combobox">
+            <%= f.search_field :music_name_or_user_name_cont, data: { autocomplete_target: 'input' }, placeholder: "検索..." %>
+            <%= f.hidden_field :music_name, data: { autocomplete_target: 'hidden' } %>
+            <ul class="list-group" data-autocomplete-target="results"></ul>
+            <%= f.submit t('defaults.search'), class: "btn-search" %>
+          </div>
         <% end %>
       </div>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,7 +2,7 @@
 
 pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
+pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.3.2/dist/js/bootstrap.esm.js"
@@ -12,3 +12,4 @@ pin "@rails/actioncable", to: "actioncable.esm.js"
 pin_all_from "app/javascript/channels", under: "channels"
 pin "jmap"
 pin "posts/index"
+pin "stimulus-autocomplete", to: "https://ga.jspm.io/npm:stimulus-autocomplete@3.1.0/src/autocomplete.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :posts do
     resources :comments, only: %i[create edit update destroy], shallow: true
     resource :like, only: %i[create]
+    get :search, on: :collection
   end
   resources :prefectures, only: %i[show]
   resource :profile, only: %i[show edit update] do


### PR DESCRIPTION
add: オートコンプリート機能を投稿検索に追加し、検索に反映するカラムを一部変更、それに伴ってmodelなどへの記述も変更しました。
1. ransackの検索に関するテーブルのカラムについての記載を使用するものに限定しました(music_nameとuserの名前)。
2. userの名前は今後必要ないと感じたら検索対象から削除しようと思います。
3. オートコンプリート機能をmusic_nameに追加しました。オートコンプリートにはstimulus-autocompleteを使用しました。