### PR TITLE
Add: 様々な検索を行えるように機能を追加、詳細アイコンの削除、思い出一覧ページの作成を実装しました

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :set_q
   
   def set_q
-    @q = Post.ransack(params[:q].try(:merge, m: 'or'))
+    @q = Post.ransack(params[:q])
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,8 +3,9 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
 
   def index
-    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page]).per(8)
-    @counts = Prefecture.all.map { |pref| Post.where(prefecture_id: pref.id).count }
+    @all_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+    @posts = @all_posts.page(params[:page]).per(8)
+    @counts = Prefecture.all.map { |pref| @posts.where(prefecture_id: pref.id).count }
   end
 
   def new
@@ -61,10 +62,14 @@ class PostsController < ApplicationController
   end
 
   def search
-    @posts = Post.where("music_name like ?", "%#{params[:q]}%")
-    respond_to do |format|
-      format.js
-    end
+    @all_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+    @posts = @all_posts.page(params[:page]).per(8)
+    @counts = Prefecture.all.map { |pref| @posts.where(prefecture_id: pref.id).count }
+    render :index
+  end
+
+  def memory_index
+    @posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(8)
   end
 
   private

--- a/app/javascript/posts/index.js
+++ b/app/javascript/posts/index.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
         heatmapColors: ["#FFE", "#FEDCBD", "#FCBB76", "#FCAF17", "#F36C21", "#F15A22"],
         backgroundColor: '#ea55040a',
         onSelect: function(e, data) {
-          window.location.href = `prefectures/${data.option.code}`;
+          window.location.href = `/prefectures/${data.option.code}`;
         },
         areas: [
           {code: 1,name: "北海道", number: document.getElementById('prefecture_1').value},

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,7 +32,7 @@ class Post < ApplicationRecord
                   }
   
   def self.ransackable_attributes(auth_object = nil)
-    ["music_name"]
+    ["music_name", "prefecture_id", "age_group"]
   end
   
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,10 +14,10 @@
 
   <body class="bg-layout">
     <%= render 'shared/header' %>
+    <%= render 'shared/flash_message' %>
     <div class="d-flex flex-row-reverse p-2">
       <%= breadcrumbs separator: " &rsaquo; " %>
     </div>
-    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/posts/_crud_menu.html.erb
+++ b/app/views/posts/_crud_menu.html.erb
@@ -1,11 +1,4 @@
 <ul class="list-unstyled list-inline float-right position-absolute bottom-0 end-0 m-3">
-  <li class="list-inline-item" id="search-post-<%= post.id %>">
-    <% unless current_page?(post_path(post)) %>
-      <%= link_to post_path(post), id: "show-post-#{post.id}" do %>
-        <i class="fa-solid fa-circle-info"></i>
-      <% end %>
-    <% end %>
-  </li>
   <% if logged_in? && current_user.mine?(post) %>
     <li class="list-inline-item">
       <%= link_to edit_post_path(post), id: "edit-post-#{post.id}" do %>

--- a/app/views/posts/_memory_post.html.erb
+++ b/app/views/posts/_memory_post.html.erb
@@ -1,0 +1,8 @@
+<div class="card content-card border-left col-sm-12 col-md-5 position-relative m-1">
+  <div class="card-body">
+    <div>
+      <%= link_to memory_post.memory, post_path(memory_post) %>
+    </div>
+  </div>
+  <%= render 'posts/crud_menu', post: memory_post %>
+</div>

--- a/app/views/posts/memory_index.html.erb
+++ b/app/views/posts/memory_index.html.erb
@@ -1,20 +1,12 @@
-<% breadcrumb :posts %>
+<% breadcrumb :posts_memory %>
 <% content_for(:title, t('.title')) %>
 <div class="container">
   <div class="row justify-content-center">
     <h1 class="mt-5 mb-5 text-center"><%= t('.title') %></h1>
-    <% if params[:q] %>
-      <h2>検索結果: <%= @all_posts.count %>件</h2>
-    <% else %>
-      <h2>投稿件数: <%= @all_posts.count %>件</h2>
-    <% end %>
-    <% Prefecture.all.each do |i| %>
-      <input type="hidden" id="prefecture_<%= i.id %>" value="<%= @counts["#{i.id - 1}".to_i] %>">
-    <% end %>
     <div id="jmap" class="col-lg-5 col-md-10 col-sm-10 offset-1"></div>
     <div class="card-deck row d-flex justify-content-evenly col-lg-5 col-md-10 offset-md-1 col-sm-10 offset-sm-1">
       <% if @posts.present? %>
-        <%= render @posts %>
+        <%= render partial: 'memory_post', collection: @posts %>
       <% else %>
         <div class="text-center m-5"><%= t('defaults.messages.no_posts') %></div>
       <% end %>
@@ -24,6 +16,3 @@
     </div>
   </div>
 </div>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<%= javascript_import_module_tag "posts/index" %>
-<%= javascript_import_module_tag 'jmap' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,17 +6,8 @@
         <h1 class="fs-1 text-white">Music Memory</h1>
         <svg class="bi" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
       <% end %>
+
       
-      <div class="nav-link">
-        <%= search_form_for @q, url: posts_path, class: "col-lg-auto mt-1 mb-lg-0 me-lg-3 text-bottom" do |f| %>
-          <div data-controller="autocomplete" data-autocomplete-url-value="/posts/search" role="combobox">
-            <%= f.search_field :music_name_or_user_name_cont, data: { autocomplete_target: 'input' }, placeholder: "検索..." %>
-            <%= f.hidden_field :music_name, data: { autocomplete_target: 'hidden' } %>
-            <ul class="list-group" data-autocomplete-target="results"></ul>
-            <%= f.submit t('defaults.search'), class: "btn-search" %>
-          </div>
-        <% end %>
-      </div>
 
       <ul class="nav nav-pills pt-1">
         <% if logged_in? %>
@@ -55,3 +46,40 @@
     </div>
   </div>
 </header>
+<div class="collapse" id="navbarToggleExternalContent">
+  <div class="bg-layout p-4">
+    <%= search_form_for @q, url: search_posts_path, html: { class: 'row g-3' } do |f| %>
+      <div class="col-md-3 mb-1">
+        <%= f.label :music_name_cont, '曲名', class: 'form-label' %>
+        <%= f.search_field :music_name_cont, class: 'form-control' %>
+      </div>
+      <div class="col-md-3 mb-1">
+        <%= f.label :user_name_cont, '投稿者', class: 'form-label' %>
+        <%= f.search_field :user_name_cont, class: 'form-control' %>
+      </div>
+      <div class="col-md-3 mb-1">
+        <%= f.label :prefecture_id_eq, '場所', class: 'form-label' %>
+        <%= f.collection_select :prefecture_id_eq, Prefecture.all, :id, :name, { include_blank: '選択なし' }, { class: 'form-select' } %>
+      </div>
+      <div class="col-md-3 mb-1">
+        <%= f.label :age_group_eq, '時代', class: 'form-label' %>
+        <%= f.select :age_group_eq, Post.age_groups_i18n.keys.map.with_index {|k, i| [Post.age_groups_i18n[k], i * 5]}, { include_blank: t('defaults.messages.age_group_placeholder')}, { class: 'form-select' } %>
+      </div>
+      <div class="col-md-3">
+        <%= f.submit '検索', class: 'btn btn-orange' %>
+      </div>
+    <% end %>
+    <div class="my-3">
+      <%= link_to "思い出一覧", memory_index_posts_path %>
+    </div>
+  </div>
+
+
+</div>
+<nav class="navbar bg-layout mt-0">
+  <div class="container-fluid">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  </div>
+</nav>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -17,6 +17,11 @@ crumb :posts_edit do |post|
   parent :posts_show, post
 end
 
+crumb :posts_memory do
+  link "思い出一覧", memory_index_posts_path
+  parent :posts
+end
+
 crumb :user_sessions_new do
   link "ログイン", login_path
   parent :posts

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -78,6 +78,8 @@ ja:
     edit:
       title: "投稿編集"
       submit: "更新"
+    memory_index:
+      title: "思い出一覧"
   comments:
     edit:
       update_submit: "更新する"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :comments, only: %i[create edit update destroy], shallow: true
     resource :like, only: %i[create]
     get :search, on: :collection
+    get :memory_index, on: :collection
   end
   resources :prefectures, only: %i[show]
   resource :profile, only: %i[show edit update] do


### PR DESCRIPTION
1. 検索結果を日本地図にも反映するようにしました。
2. フラッシュメッセージの位置を変更しました。
3. 詳細アイコンを削除しました。
4. 思い出のみの一覧を作成しました。
5. Headerに配置していた検索欄を削除し、新しく検索欄を設定しました。検索欄ではユーザー名、聞いた地域、曲名で検索できるようにしています。また、思い出一覧へのリンクも検索のようなものであると考えられるためここに配置しました。