### PR TITLE
Modify: 検索結果後の地域ページに検索結果、地域と年代のタグ化と検索結果表示を可能にしました。

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -68,6 +68,20 @@ class PostsController < ApplicationController
     render :index
   end
 
+  def age_search
+    @all_posts = Post.where(age_group: params[:age_group]).includes(:user).order(created_at: :desc)
+    @posts = @all_posts.page(params[:page]).per(8)
+    @counts = Prefecture.all.map { |pref| @posts.where(prefecture_id: pref.id).count }
+    render :index
+  end
+
+  def prefecture_search
+    @all_posts = Post.where(prefecture_id: params[:prefecture_id]).includes(:user).order(created_at: :desc)
+    @posts = @all_posts.page(params[:page]).per(8)
+    @counts = Prefecture.all.map { |pref| @posts.where(prefecture_id: pref.id).count }
+    render :index
+  end
+
   def memory_index
     @posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(8)
   end

--- a/app/controllers/prefectures_controller.rb
+++ b/app/controllers/prefectures_controller.rb
@@ -1,7 +1,15 @@
 class PrefecturesController < ApplicationController
   skip_before_action :require_login, only: %i[show]
   def show
-    @posts = Post.where(prefecture_id: params[:id]).includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+    @all_posts = Post.where(prefecture_id: params[:id]).includes(:user)
+    @posts = @all_posts.order(created_at: :desc).page(params[:page]).per(10)
     @prefecture = Prefecture.find(params[:id])
+  end
+
+  def search
+    @all_posts = @q.result(distinct: true).where(prefecture_id: params[:prefecture_id]).includes(:user)
+    @posts = @all_posts.order(created_at: :desc).page(params[:page]).per(10)
+    @prefecture = Prefecture.find(params[:prefecture_id])
+    render :show
   end
 end

--- a/app/javascript/posts/index.js
+++ b/app/javascript/posts/index.js
@@ -1,4 +1,8 @@
 document.addEventListener("DOMContentLoaded", (event) => {
+  const currentUrl = window.location.href
+  const urlSplit = currentUrl.split('/')
+  const urlLast = urlSplit[urlSplit.length - 1]
+  const urlJudge = urlLast.includes('search')
   $(document).ready(function() {
     $('#jmap').jmap({
         width: '100%',
@@ -31,7 +35,11 @@ document.addEventListener("DOMContentLoaded", (event) => {
         heatmapColors: ["#FFE", "#FEDCBD", "#FCBB76", "#FCAF17", "#F36C21", "#F15A22"],
         backgroundColor: '#ea55040a',
         onSelect: function(e, data) {
-          window.location.href = `/prefectures/${data.option.code}`;
+          if (urlJudge) {
+            window.location.href = `/prefectures/${data.option.code}/${urlSplit[urlSplit.length - 1]}`;
+          } else {
+            window.location.href = `/prefectures/${data.option.code}`;
+          }
         },
         areas: [
           {code: 1,name: "北海道", number: document.getElementById('prefecture_1').value},

--- a/app/views/posts/_memory_post.html.erb
+++ b/app/views/posts/_memory_post.html.erb
@@ -1,4 +1,4 @@
-<div class="card content-card border-left col-sm-12 col-md-5 position-relative m-1">
+<div class="card content-card border-left col-12 position-relative m-1">
   <div class="card-body">
     <div>
       <%= link_to memory_post.memory, post_path(memory_post) %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -6,11 +6,20 @@
     <div>
       <%= "#{t('defaults.contributor')}: " %><%= link_to post.user.name, user_path(post.user) %>
     </div>
-    <div>
-      <%= post.age_group_i18n %>
-    </div>
-    <div>
-      <%= "#{post.prefecture.name}" if post.prefecture.present? %>
+    <div class="d-flex mt-2">
+      <% if post.age_group.present? %>
+        <%= search_form_for @q, url: search_posts_path, html: { class: 'me-2' } do |f| %>
+          <%= f.hidden_field :age_group_eq, value: post.age_group_before_type_cast %>
+          <%= f.submit post.age_group_i18n, class: 'btn btn-orange btn-sm rounded-pill' %>
+        <% end %>
+      <% end %>
+      
+      <% if post.prefecture.present? %>
+        <%= search_form_for @q, url: search_posts_path, html: { class: 'me-2' } do |f| %>
+          <%= f.hidden_field :prefecture_id_eq, value: post.prefecture_id %>
+          <%= f.submit post.prefecture.name, class: 'btn btn-orange btn-sm rounded-pill' %>
+        <% end %>
+      <% end %>
     </div>
   </div>
   <%= render 'posts/crud_menu', post: post %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,11 +3,13 @@
 <div class="container">
   <div class="row justify-content-center">
     <h1 class="mt-5 mb-5 text-center"><%= t('.title') %></h1>
-    <% if params[:q] %>
-      <h2>検索結果: <%= @all_posts.count %>件</h2>
-    <% else %>
-      <h2>投稿件数: <%= @all_posts.count %>件</h2>
-    <% end %>
+    <div class="col-10 offset-1">
+      <% if params[:q] %>
+        <h2>検索件数: <%= @all_posts.count %>件</h2>
+      <% else %>
+        <h2>投稿件数: <%= @all_posts.count %>件</h2>
+      <% end %>
+    </div>
     <% Prefecture.all.each do |i| %>
       <input type="hidden" id="prefecture_<%= i.id %>" value="<%= @counts["#{i.id - 1}".to_i] %>">
     <% end %>

--- a/app/views/posts/memory_index.html.erb
+++ b/app/views/posts/memory_index.html.erb
@@ -3,8 +3,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <h1 class="mt-5 mb-5 text-center"><%= t('.title') %></h1>
-    <div id="jmap" class="col-lg-5 col-md-10 col-sm-10 offset-1"></div>
-    <div class="card-deck row d-flex justify-content-evenly col-lg-5 col-md-10 offset-md-1 col-sm-10 offset-sm-1">
+    <div class="card-deck row d-flex justify-content-evenly col-lg-10 col-md-10 col-sm-10">
       <% if @posts.present? %>
         <%= render partial: 'memory_post', collection: @posts %>
       <% else %>

--- a/app/views/prefectures/show.html.erb
+++ b/app/views/prefectures/show.html.erb
@@ -3,7 +3,14 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="card-deck row d-flex justify-content-evenly m-1">
-      <h1 class="p-5"><%= t('.title', prefecture: @prefecture.name) %></h1>
+      <h1 class="p-5 text-center"><%= t('.title', prefecture: @prefecture.name) %></h1>
+      <div class="col-10">
+        <% if params[:q] %>
+          <h2>件数: <%= @all_posts.count %>件</h2>
+        <% else %>
+          <h2>投稿件数: <%= @all_posts.count %>件</h2>
+        <% end %>
+      </div>
       <% if @posts.present? %>
         <%= render partial: 'post', collection: @posts %>
         <div class="mt-5">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,9 +6,7 @@
         <h1 class="fs-1 text-white">Music Memory</h1>
         <svg class="bi" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
       <% end %>
-
       
-
       <ul class="nav nav-pills pt-1">
         <% if logged_in? %>
           <li class="nav-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,12 @@ Rails.application.routes.draw do
     resource :like, only: %i[create]
     get :search, on: :collection
     get :memory_index, on: :collection
+    get :age_search, on: :collection
+    get :prefecture_search, on: :collection
   end
-  resources :prefectures, only: %i[show]
+  resources :prefectures, only: %i[show] do
+    get :search
+  end
   resource :profile, only: %i[show edit update] do
     collection do
       get :follows, :followers, :likes, :my_posts


### PR DESCRIPTION
1. これまで検索結果後の日本地図は検索件数は表示されていましたが特定の都道府県を押しても検索結果は地域ページでは反映されていませんでしたが、反映されるように変更しました。
2. 地域と年代をタグのようなUIに変更しました。
3. タグを押すと検索結果が投稿一覧に検索結果として表示され、それらも日本地図に検索数として反映されるようにしました。