### PR TITLE
Modify: プロフィール下の~投稿一覧などのレイアウトを変更、おすすめ投稿一覧を作成、ヘッダーに記述した検索をパーシャルに分けました

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,15 +23,11 @@ a {
   }
 }
 
-.header-color {
-  color: white;
-}
-
-h1, div, p, small, .title-color, .orange-color {
+h1, div, p, small, .title-color {
   color: #ea5504;
 }
 
-.orange-color {
+.text-orange {
   color: #ea5504;
 }
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,6 +4,8 @@ class ProfilesController < ApplicationController
     @my_user_room = UserRoom.where(user_id: current_user.id)
     @like_posts = current_user.like_posts.includes(:user).order(created_at: :desc).last(5)
     @my_posts = current_user.posts.order(created_at: :desc).last(5)
+    @following_user_ids = current_user.following_users.pluck(:id)
+    @recommend_follow_posts = Post.where(user_id: @following_user_ids).includes(:user).order("RANDOM()").limit(5)
   end
 
   def edit
@@ -34,6 +36,11 @@ class ProfilesController < ApplicationController
 
   def my_posts
     @my_posts = current_user.posts.order(age_group: :asc, created_at: :asc).page(params[:page]).per(12)
+  end
+
+  def recommend_posts
+    @following_user_ids = current_user.following_users.pluck(:id)
+    @recommend_posts = Post.where(user_id: @following_user_ids).includes(:user).order("RANDOM()").page(params[:page]).per(10)
   end
 
   private

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <h1 class="mt-5 mb-5 text-center"><%= t('.title') %></h1>
-    <div class="col-10 offset-1">
+    <div class="col-10">
       <% if params[:q] %>
         <h2>検索件数: <%= @all_posts.count %>件</h2>
       <% else %>

--- a/app/views/profiles/_post.html.erb
+++ b/app/views/profiles/_post.html.erb
@@ -1,5 +1,5 @@
-<div class="card content-card border-left col-sm-12 col-md-5 position-relative m-1">
-  <div class="m-2 text-center">
+<div class="card content-card border-left col-sm-12 col-md-10 offset-md-1 col-lg-5 position-relative m-1">
+  <div class="my-4 text-center">
     <%= link_to post.music_name, post_path(post), class: "fs-3" %>
   </div>
   <div class="card-body">

--- a/app/views/profiles/my_posts.html.erb
+++ b/app/views/profiles/my_posts.html.erb
@@ -1,14 +1,14 @@
 <% breadcrumb :profiles_my_posts %>
 <% content_for(:title, t('.title')) %>
 <div class="container">
-  <div class="row">
+  <div class="row justify-content-center">
     <div class="card-deck row d-flex justify-content-evenly">
       <h1 class="text-center my-5"><%= t('.title') %></h1>
       <% current_age_group = nil %>
       <% @my_posts.each do |post| %>
-        <% if current_age_group != post.age_group %>
-          <% current_age_group = post.age_group %>
-          <h2 class="text-center my-5"><%= post.age_group_i18n %>時代</h2>
+        <% if current_age_group != post.age_group_i18n %>
+          <% current_age_group = post.age_group_i18n %>
+          <h2 class="text-center my-5"><%= post.age_group_i18n %></h2>
         <% end %>
         <%= render partial: 'post', locals: { post: post } %>
       <% end %>

--- a/app/views/profiles/recommend_posts.html.erb
+++ b/app/views/profiles/recommend_posts.html.erb
@@ -1,17 +1,17 @@
-<% breadcrumb :profiles_likes %>
+<% breadcrumb :profiles_recommend_posts %>
 <% content_for(:title, t('.title')) %>
 <div class="container">
   <div class="row justify-content-center">
     <div class="card-deck row d-flex justify-content-evenly">
       <h1 class="text-center my-5"><%= t('.title') %></h1>
-      <% if @like_posts.present? %>
-        <%= render partial: 'post', collection: @like_posts %>
+      <% if @recommend_posts.present? %>
+        <%= render partial: 'post', collection: @recommend_posts %>
       <% else %>
         <div class="text-center m-5"><%= t('defaults.messages.no_posts') %></div>
       <% end %>
     </div>
     <div class="mt-5">
-      <%= paginate @like_posts, theme: 'bootstrap-5' %>
+      <%= paginate @recommend_posts, theme: 'bootstrap-5' %>
     </div>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -52,7 +52,7 @@
       </div>
       <div>
         <%= link_to t('.my_posts'), my_posts_profile_path, class:"btn btn-orange container-fluid" %>
-        <div class="card">
+        <div class="card mb-5">
           <table class="table table-striped">
             <thead>
               <th><%= Post.human_attribute_name(:music_name) %></th>
@@ -63,6 +63,20 @@
           </table>
         </div>
       </div>
+
+      <div>
+        <%= link_to "> おすすめの投稿", recommend_posts_profile_path, class:"btn btn-orange container-fluid" %>
+        <div class="card">
+          <table class="table table-striped">
+            <thead>
+              <th><%= Post.human_attribute_name(:music_name) %></th>
+              <th><%= Post.human_attribute_name(:memory) %></th>
+            </thead>
+            <%= render partial: 'simple_post', collection: @recommend_follow_posts %>
+          </table>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,6 @@
         <h1 class="fs-1 text-white">Music Memory</h1>
         <svg class="bi" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"></use></svg>
       <% end %>
-
       <ul class="nav nav-pills pt-1">
         <% if logged_in? %>
           <li class="nav-item">
@@ -30,8 +29,8 @@
                 <i class="fa-regular fa-user fs-5"></i>
               </button>
               <ul class="dropdown-menu bg-white">
-                <li><%= link_to t('defaults.mypage'), profile_path, class: "dropdown-item orange-color" %></li>
-                <li><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "dropdown-item orange-color" %></li>
+                <li><%= link_to t('defaults.mypage'), profile_path, class: "dropdown-item text-orange" %></li>
+                <li><%= link_to t('defaults.logout'), logout_path, method: :delete, class: "dropdown-item text-orange" %></li>
               </ul>
             </div>
           </li>
@@ -45,43 +44,15 @@
   </div>
 </header>
 <div class="collapse" id="navbarToggleExternalContent">
-  <div class="bg-layout p-4">
-    <%= search_form_for @q, url: search_posts_path, html: { class: 'row g-3' } do |f| %>
-      <div class="col-md-3 mb-1">
-        <%= f.label :music_name_cont, '曲名', class: 'form-label' %>
-        <%= f.search_field :music_name_cont, class: 'form-control' %>
-      </div>
-      <div class="col-md-3 mb-1">
-        <%= f.label :user_name_cont, '投稿者', class: 'form-label' %>
-        <%= f.search_field :user_name_cont, class: 'form-control' %>
-      </div>
-      <div class="col-md-3 mb-1">
-        <%= f.label :prefecture_id_eq, '場所', class: 'form-label' %>
-        <%= f.collection_select :prefecture_id_eq, Prefecture.all, :id, :name, { include_blank: '選択なし' }, { class: 'form-select' } %>
-      </div>
-      <div class="col-md-3 mb-1">
-        <%= f.label :age_group_eq, '時代', class: 'form-label' %>
-        <%= f.select :age_group_eq, Post.age_groups_i18n.keys.map.with_index {|k, i| [Post.age_groups_i18n[k], i * 5]}, { include_blank: t('defaults.messages.age_group_placeholder')}, { class: 'form-select' } %>
-      </div>
-      <div class="col-md-3">
-        <%= f.submit '検索', class: 'btn btn-orange' %>
-      </div>
-    <% end %>
-    <div class="my-3">
-      <%= link_to "思い出一覧", memory_index_posts_path %>
-    </div>
-  </div>
-
-
+  <%= render 'shared/search_form', q: @q %>
 </div>
 <nav class="navbar bg-layout mt-0">
   <div class="container-fluid">
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
+    <button class="navbar-toggler p-2 arrow-button" id="myButton" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="text-orange">検索 </span><i class="fa-solid fa-caret-down text-orange" id="navbarIcon"></i>
     </button>
   </div>
 </nav>
-
 <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,23 @@
+<div class="bg-layout p-4">
+  <%= search_form_for q, url: search_posts_path, html: { class: 'row g-3' } do |f| %>
+    <div class="col-md-3 mb-1">
+      <%= f.label :music_name_cont, '曲名', class: 'form-label' %>
+      <%= f.search_field :music_name_cont, class: 'form-control' %>
+    </div>
+    <div class="col-md-3 mb-1">
+      <%= f.label :user_name_cont, '投稿者', class: 'form-label' %>
+      <%= f.search_field :user_name_cont, class: 'form-control' %>
+    </div>
+    <div class="col-md-3 mb-1">
+      <%= f.label :prefecture_id_eq, '場所', class: 'form-label' %>
+      <%= f.collection_select :prefecture_id_eq, Prefecture.all, :id, :name, { include_blank: '選択なし' }, { class: 'form-select' } %>
+    </div>
+    <div class="col-md-3 mb-1">
+      <%= f.label :age_group_eq, '時代', class: 'form-label' %>
+      <%= f.select :age_group_eq, Post.age_groups_i18n.keys.map.with_index {|k, i| [Post.age_groups_i18n[k], i * 5]}, { include_blank: t('defaults.messages.age_group_placeholder')}, { class: 'form-select' } %>
+    </div>
+    <div class="col-md-3">
+      <%= f.submit '検索', class: 'btn btn-orange' %>
+    </div>
+  <% end %>
+</div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -67,6 +67,11 @@ crumb :profiles_my_posts do
   parent :profiles
 end
 
+crumb :profiles_recommend_posts do
+  link "おすすめの投稿", recommend_posts_profile_path
+  parent :profiles
+end
+
 crumb :rooms_index do
   link "チャットルーム一覧", rooms_path
   parent :profiles

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -103,6 +103,8 @@ ja:
       title: "いいねした投稿"
     my_posts:
       title: "あなたの投稿"
+    recommend_posts:
+      title: "おすすめの投稿"
   rooms:
     index:
       title: "チャットルーム一覧"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   end
   resource :profile, only: %i[show edit update] do
     collection do
-      get :follows, :followers, :likes, :my_posts
+      get :follows, :followers, :likes, :my_posts, :recommend_posts
     end
   end
   resources :rooms, only: %i[index show create destroy] do


### PR DESCRIPTION
1. プロフィールコントローラの自身の投稿、いいねした投稿に関してレイアウトを変更しました。
2. おすすめの投稿一覧を作成してプロフィール詳細で5つまで、そこからおすすめ投稿一覧ページに移動できるようにしました。おすすめの仕方は自身のフォローした相手としていますので今後フォローしていない時についてや他のおすすめ内容を追加していきます。
3. _header.html.erbに記述していた検索フォーム関連をパーシャルで分けました。