### PR TITLE
modify: 日本地図に関する動作不良の改良、検索のアイコンを一時変更しました。

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,8 +4,9 @@ class PostsController < ApplicationController
 
   def index
     @all_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
-    @posts = @all_posts.page(params[:page]).per(8)
-    @counts = Prefecture.all.map { |pref| @posts.where(prefecture_id: pref.id).count }
+    @posts = @all_posts.page(params[:page]).per(6)
+    @prefectures = Prefecture.all
+    @counts = @prefectures.map { |pref| @all_posts.where(prefecture_id: pref.id).count }
   end
 
   def new
@@ -63,8 +64,9 @@ class PostsController < ApplicationController
 
   def search
     @all_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
-    @posts = @all_posts.page(params[:page]).per(8)
-    @counts = Prefecture.all.map { |pref| @posts.where(prefecture_id: pref.id).count }
+    @posts = @all_posts.page(params[:page]).per(6)
+    @prefectures = Prefecture.all
+    @counts = @prefectures.map { |pref| @all_posts.where(prefecture_id: pref.id).count }
     render :index
   end
 

--- a/app/javascript/posts/index.js
+++ b/app/javascript/posts/index.js
@@ -2,7 +2,27 @@ document.addEventListener("DOMContentLoaded", (event) => {
   const currentUrl = window.location.href
   const urlSplit = currentUrl.split('/')
   const urlLast = urlSplit[urlSplit.length - 1]
-  const urlJudge = urlLast.includes('search')
+  const urlSearch = urlLast.includes('search')
+  const pattern = /page=\d+&/
+  const urlPage = urlLast.includes('?page=')
+  const modifiedString = urlLast.replace(pattern, '')
+  const post_numbers = function(pre_num) { 
+    const preId = document.querySelector(`#prefecture_${pre_num}`)
+    const className = preId.className;
+    return className
+  }
+  const prefecture_names = function(pre_name) {
+    const prefName = document.querySelector(`#prefecture_${pre_name}`).value
+    return prefName
+  }
+  const areas = Array.from({ length: 47 }, (_, i) => {
+    const code = i + 1;
+    return {
+      code: code,
+      name: prefecture_names(code),
+      number: post_numbers(code)
+    };
+  });
   $(document).ready(function() {
     $('#jmap').jmap({
         width: '100%',
@@ -35,61 +55,13 @@ document.addEventListener("DOMContentLoaded", (event) => {
         heatmapColors: ["#FFE", "#FEDCBD", "#FCBB76", "#FCAF17", "#F36C21", "#F15A22"],
         backgroundColor: '#ea55040a',
         onSelect: function(e, data) {
-          if (urlJudge) {
-            window.location.href = `/prefectures/${data.option.code}/${urlSplit[urlSplit.length - 1]}`;
+          if (urlSearch && urlPage) {
+            window.location.href = `/prefectures/${data.option.code}/${modifiedString}`;
           } else {
             window.location.href = `/prefectures/${data.option.code}`;
           }
         },
-        areas: [
-          {code: 1,name: "北海道", number: document.getElementById('prefecture_1').value},
-          {code: 2,name: "青森", number: document.getElementById('prefecture_2').value},
-          {code: 3,name: "岩手", number: document.getElementById('prefecture_3').value},
-          {code: 4,name: "宮城", number: document.getElementById('prefecture_4').value},
-          {code: 5,name: "秋田", number: document.getElementById('prefecture_5').value},
-          {code: 6,name: "山形", number: document.getElementById('prefecture_6').value},
-          {code: 7,name: "福島", number: document.getElementById('prefecture_7').value},
-          {code: 8,name: "茨城", number: document.getElementById('prefecture_8').value},
-          {code: 9,name: "栃木", number: document.getElementById('prefecture_9').value},
-          {code: 10,name: "群馬", number: document.getElementById('prefecture_10').value},
-          {code: 11,name: "埼玉", number: document.getElementById('prefecture_11').value},
-          {code: 12,name: "千葉", number: document.getElementById('prefecture_12').value},
-          {code: 13,name: "東京", number: document.getElementById('prefecture_13').value},
-          {code: 14,name: "神奈川", number: document.getElementById('prefecture_14').value},
-          {code: 15,name: "新潟", number: document.getElementById('prefecture_15').value},
-          {code: 16,name: "富山", number: document.getElementById('prefecture_16').value},
-          {code: 17,name: "石川", number: document.getElementById('prefecture_17').value},
-          {code: 18,name: "福井", number: document.getElementById('prefecture_18').value},
-          {code: 19,name: "山梨", number: document.getElementById('prefecture_19').value},
-          {code: 20,name: "長野", number: document.getElementById('prefecture_20').value},
-          {code: 21,name: "岐阜", number: document.getElementById('prefecture_21').value},
-          {code: 22,name: "静岡", number: document.getElementById('prefecture_22').value},
-          {code: 23,name: "愛知", number: document.getElementById('prefecture_23').value},
-          {code: 24,name: "三重", number: document.getElementById('prefecture_24').value},
-          {code: 25,name: "滋賀", number: document.getElementById('prefecture_25').value},
-          {code: 26,name: "京都", number: document.getElementById('prefecture_26').value},
-          {code: 27,name: "大阪", number: document.getElementById('prefecture_27').value},
-          {code: 28,name: "兵庫", number: document.getElementById('prefecture_28').value},
-          {code: 29,name: "奈良", number: document.getElementById('prefecture_29').value},
-          {code: 30,name: "和歌山", number: document.getElementById('prefecture_30').value},
-          {code: 31,name: "鳥取", number: document.getElementById('prefecture_31').value},
-          {code: 32,name: "島根", number: document.getElementById('prefecture_32').value},
-          {code: 33,name: "岡山", number: document.getElementById('prefecture_33').value},
-          {code: 34,name: "広島", number: document.getElementById('prefecture_34').value},
-          {code: 35,name: "山口", number: document.getElementById('prefecture_35').value},
-          {code: 36,name: "徳島", number: document.getElementById('prefecture_36').value},
-          {code: 37,name: "香川", number: document.getElementById('prefecture_37').value},
-          {code: 38,name: "愛媛", number: document.getElementById('prefecture_38').value},
-          {code: 39,name: "高知", number: document.getElementById('prefecture_39').value},
-          {code: 40,name: "福岡", number: document.getElementById('prefecture_40').value},
-          {code: 41,name: "佐賀", number: document.getElementById('prefecture_41').value},
-          {code: 42,name: "長崎", number: document.getElementById('prefecture_42').value},
-          {code: 43,name: "熊本", number: document.getElementById('prefecture_43').value},
-          {code: 44,name: "大分", number: document.getElementById('prefecture_44').value},
-          {code: 45,name: "宮崎", number: document.getElementById('prefecture_45').value},
-          {code: 46,name: "鹿児島", number: document.getElementById('prefecture_46').value},
-          {code: 47,name: "沖縄", number: document.getElementById('prefecture_47').value}
-          ]
+        areas: areas
     });
   });
 });

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,8 +10,8 @@
         <h2>投稿件数: <%= @all_posts.count %>件</h2>
       <% end %>
     </div>
-    <% Prefecture.all.each do |i| %>
-      <input type="hidden" id="prefecture_<%= i.id %>" value="<%= @counts["#{i.id - 1}".to_i] %>">
+    <% @prefectures.each do |prefecture| %>
+      <input type="hidden" class="<%= @counts["#{prefecture.id - 1}".to_i] %>" id="prefecture_<%= prefecture.id %>" value="<%= prefecture.name %>">
     <% end %>
     <div id="jmap" class="col-lg-6 col-md-10 col-sm-10 offset-lg col-lg-5 col-md-10 mx-auto"></div>
     <div class="card-deck row d-flex justify-content-evenly col-lg-5 col-md-10 col-sm-10 ">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -60,7 +60,7 @@
 <nav class="navbar bg-layout mt-0">
   <div class="container-fluid">
     <button class="navbar-toggler p-2 arrow-button" id="myButton" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
-      <i class="fa-solid fa-magnifying-glass text-orange"></i><span class="text-orange"> 検索</span>
+      </i><span class="text-orange">検索 ▼</span>
     </button>
   </div>
 </nav>


### PR DESCRIPTION
1. 使用する日本地図のjavascript内のコードをリファクタリングしました。
2. 検索結果が存在する時にページが進んでから都道府県をクリックしたときにpageも指定されてしまう挙動を正常に変更しました。
3. pageが進むと日本地図に濃さが反映されない問題を解決しました。
4. ページごとに表示する投稿数を8から6へ変更しました。
5. 検索のアイコンを一時変更しました。